### PR TITLE
Add missing requirements and updated versions

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,15 @@
+# runtime requirements
+datalad>=0.16
+datalad-metalad>=0.3.10
+jsonschema
+yaml2
+
 # requirements for a development environment
 pytest
 nose
 coverage
+
+# requirements for a document building
 sphinx
 sphinx_rtd_theme
 sphinx_copybutton

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,9 @@ classifiers =
 python_requires = >= 3.7
 install_requires =
     datalad >= 0.16
-    datalad-metalad >= 0.3.2
+    datalad-metalad >= 0.3.10
     jsonschema
+    yaml2
 packages = find:
 include_package_data = True
 


### PR DESCRIPTION
Fixes issue #105 

This PR does two things:

- add missing requirements to `requirements-devel,txt`. This file is used in the CI-tests
- update the datalad-metalad minimum version to include a recent bugfix