### PR TITLE
MNT: Make import statements comply to design doc

### DIFF
--- a/datalad_catalog/catalog.py
+++ b/datalad_catalog/catalog.py
@@ -1,24 +1,43 @@
-from os.path import curdir
-from os.path import abspath
-import logging
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
-from datalad.interface.utils import eval_results
-from datalad.interface.results import get_status_dict
-from datalad.log import log_progress
-from datalad.support.param import Parameter
-from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.distribution.dataset import datasetmethod
-from datalad.support.constraints import EnsureChoice
-import sys
-from pathlib import Path
 import json
+import logging
 import os
-from typing import Dict, List, Optional, Tuple, Union
-from .webcatalog import WebCatalog, Node
-from .utils import read_json_file
-from .meta_item import MetaItem
-from jsonschema import ValidationError, Draft202012Validator, RefResolver
+import sys
+from os.path import (
+    abspath,
+    curdir,
+)
+from pathlib import Path
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
+from datalad.distribution.dataset import datasetmethod
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import eval_results
+from datalad.log import log_progress
+from datalad.support.constraints import EnsureChoice
+from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.support.param import Parameter
+from jsonschema import (
+    Draft202012Validator,
+    RefResolver,
+    ValidationError,
+)
+
+from datalad_catalog.meta_item import MetaItem
+from datalad_catalog.utils import read_json_file
+from datalad_catalog.webcatalog import (
+    Node,
+    WebCatalog,
+)
 
 # Create named logger
 lgr = logging.getLogger("datalad.catalog.catalog")

--- a/datalad_catalog/meta_item.py
+++ b/datalad_catalog/meta_item.py
@@ -1,10 +1,16 @@
 # from abc import ABC, abstractmethod
-from pathlib import Path
-from . import constants as cnst
-from .webcatalog import WebCatalog, Node, getNode
-from .utils import read_json_file
-from datalad.interface.results import get_status_dict
 import logging
+from pathlib import Path
+
+from datalad.interface.results import get_status_dict
+
+from datalad_catalog import constants as cnst
+from datalad_catalog.utils import read_json_file
+from datalad_catalog.webcatalog import (
+    Node,
+    WebCatalog,
+    getNode,
+)
 
 lgr = logging.getLogger("datalad.catalog.meta_item")
 

--- a/datalad_catalog/webcatalog.py
+++ b/datalad_catalog/webcatalog.py
@@ -1,13 +1,21 @@
-import sys
-import json
-from pathlib import Path
-import shutil
 import hashlib
-from . import constants as cnst
+import json
 import logging
-from .utils import read_json_file, find_duplicate_object_in_list
-from jsonschema import Draft202012Validator, RefResolver
+import shutil
+import sys
+from pathlib import Path
+
 import yaml
+from jsonschema import (
+    Draft202012Validator,
+    RefResolver,
+)
+
+import datalad_catalog.constants as cnst
+from datalad_catalog.utils import (
+    find_duplicate_object_in_list,
+    read_json_file,
+)
 
 lgr = logging.getLogger("datalad.catalog.webcatalog")
 


### PR DESCRIPTION
This restructures and rewrites Python import statements
to better comply to DataLad Core's design document at
http://docs.datalad.org/en/stable/design/python_imports.html.
I have decided to resolve relative imports completely - but
this decision is more personal taste and can be debated.
Fixes https://github.com/datalad/datalad-catalog/issues/108