### PR TITLE
DOC: Add the basic example structure to exposed extension command

### DIFF
--- a/datalad_catalog/catalog.py
+++ b/datalad_catalog/catalog.py
@@ -35,6 +35,11 @@ class Catalog(Interface):
     (Long description of arbitrary volume.)
     """
 
+    _examples_ = [
+        dict(text="TODO",
+             code_py="TODO",
+             code_cmd="TODO"),
+    ]
     # parameters of the command, must be exhaustive
     _params_ = dict(
         # name of the parameter, must match argument name


### PR DESCRIPTION
This paves the way and serves as a reminder to create examples
in python and CMD to be rendered in the help texts and the docs