### PR TITLE
Use pytest instead of nosetest in crippled-filesystems tests

### DIFF
--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         pip install -r requirements-devel.txt
         python -m pip install --upgrade pip
-    - name: Installation
+    - name: Install datalad_catalog
       run: |
         # package install
         python -m pip install --upgrade .
@@ -52,4 +52,4 @@ jobs:
         echo "== mount >>"
         mount
         echo "<< mount =="
-        python -m nose -s -v --with-doctest --with-coverage --cover-package datalad_catalog datalad_catalog
+        coverage run -m pytest -s -v datalad_catalog


### PR DESCRIPTION
Fixes issue #111 

This PR modifies the action that performs crippled filesystem tests to use `pytest` instead of `nose`.

