### PR TITLE
MNT: Unify command line and Python API command name

### DIFF
--- a/datalad_catalog/__init__.py
+++ b/datalad_catalog/__init__.py
@@ -18,7 +18,7 @@ command_suite = (
             # optional name of the command in the cmdline API
             "catalog",
             # optional name of the command in the Python API
-            "catalog_cmd",
+            "catalog",
         ),
     ],
 )


### PR DESCRIPTION
Previously, I would have needed to import the main command of
this extension like this in its Python API:
>>> from datalad.api import catalog_cmd

This created a mismatch between the CMD line API (datalad catalog)
and the Python API (catalog_cmd). To resolve this mismatch
and unify command naming to how it is done in most other parts
of the DataLad universe, this commit changes the Python API
name to 'catalog', such that the necessary import becomes

>>> from datalad.api import catalog

Fixes #115