### PR TITLE
DOC: update installation instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,20 +12,20 @@ environment and ensure you have a recent version of Python installed.
 Then activate the environment.
 
 
-With `virtualenv`_:
+With `venv`_:
 
 .. code-block:: bash
 
-    virtualenv mycatalogenv
-    source mycatalogenv/bin/activate
+    python -m venv my_catalog_env
+    source my_catalog_env/bin/activate
 
 
 With `miniconda`_:
 
 .. code-block:: bash
    
-    conda create -n mycatalogenv python=3.9
-    conda activate mycatalogenv
+    conda create -n my_catalog_env python=3.9
+    conda activate my_catalog_env
 
 
 Step 2 - Clone the repo and install the package
@@ -43,19 +43,25 @@ Congratulations! You have now installed DataLad Catalog!
 Dependencies
 ============
 
-.. admonition:: TODO
+Because this is an extension to ``datalad`` and builds on metadata handling
+functionality, the installation process also installed `datalad`_ and
+`datalad-metalad`_ as dependencies, although these do not have to be used as the
+only sources of metadata for a catalog.
 
-    - Confirm and list all dependencies
-    - Provide separate installation instructions where needed
-    - Describe DataLad installation process in short, git-annex
-    - Separate usage dependencies from development dependencies
+While the catalog generation process does not expect data to be structured as
+DataLad datasets, it can still be very useful to do so when building a full
+(meta)data management pipeline from raw data to catalog publishing. For complete
+instructions on how to install ``datalad`` and ``git-annex``, please refer to the
+`DataLad Handbook`_.
 
-DataLad Catalog has the following core dependencies:
+Similarly, the metadata input to ``datalad-catalog`` can come from any source as
+long as it conforms to the catalog schema. While the catalog does not expect
+metadata originating only from ``datalad-metalad``'s extractors, this tool has
+advanced metadata handling capabilities that will integrate seamlessly with
+DataLad datasets and the catalog generation process.
 
-- datalad
-- datalad-metalad
-- sphinx (for documentation)
-- pytest (for testing)
-
-.. _virtualenv: https://github.com/pypa/virtualenv
+.. _venv: https://github.com/pypa/virtualenv
 .. _miniconda: https://docs.conda.io/en/latest/miniconda.html
+.. _datalad: https://github.com/datalad/datalad
+.. _datalad-metalad: https://github.com/datalad/datalad-metalad
+.. _DataLad Handbook: https://handbook.datalad.org/en/latest/intro/installation.html


### PR DESCRIPTION
Updates the installation instructions to be inline with the `README` and adds information on the dependencies.

Towards #103 
