### PR TITLE
Add tests for datalad_catalog/catalog.py and refactor tested module

### DIFF
--- a/datalad_catalog/catalog.py
+++ b/datalad_catalog/catalog.py
@@ -239,11 +239,27 @@ class Catalog(Interface):
         # Call relevant function based on action
         # Action-specific argument parsing as well as results yielding are done within action-functions
         function, args = {
-            "create": (_create_catalog, (ctlg, metadata, dataset_id, dataset_version, force, config_file)),
+            "create": (
+                _create_catalog,
+                (
+                    ctlg,
+                    metadata,
+                    dataset_id,
+                    dataset_version,
+                    force,
+                    config_file,
+                ),
+            ),
             "serve": (_serve_catalog, (ctlg,)),
             "add": (_add_to_catalog, (ctlg, metadata)),
-            "remove": (_remove_from_catalog, (ctlg, dataset_id, dataset_version)),
-            "set-super": (_set_super_of_catalog, (ctlg, dataset_id, dataset_version)),
+            "remove": (
+                _remove_from_catalog,
+                (ctlg, dataset_id, dataset_version),
+            ),
+            "set-super": (
+                _set_super_of_catalog,
+                (ctlg, dataset_id, dataset_version),
+            ),
         }[catalog_action]
 
         yield from function(*args)

--- a/datalad_catalog/tests/test_catalog.py
+++ b/datalad_catalog/tests/test_catalog.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 from unittest.mock import (
@@ -64,7 +63,7 @@ def test_empty_metadata_detection():
         InsufficientArgumentsError,
         _unwind,
         _validate_metadata,
-        [None, None, None, None, False, None],
+        [None,],
     )
 
 
@@ -74,7 +73,7 @@ def test_schema_violation_detection(metadata_file: str = ""):
         ValidationError,
         _unwind,
         _validate_metadata,
-        [None, metadata_file, None, None, False, None],
+        [metadata_file,],
     )
 
 
@@ -86,7 +85,7 @@ def test_metadata_type_mismatch_detection(metadata_file: str = ""):
             ValidationError,
             _unwind,
             _validate_metadata,
-            [None, metadata_file, None, None, False, None],
+            [metadata_file,],
         )
         assert_in(
             call(
@@ -102,7 +101,7 @@ def test_metadata_type_mismatch_detection(metadata_file: str = ""):
 @with_tempfile(content=minimal_metadata)
 def test_proper_validation(metadata_file: str = ""):
     result = tuple(
-        _validate_metadata(None, metadata_file, None, None, False, None)
+        _validate_metadata(metadata_file)
     )[0]
     assert_equal(result["status"], "ok")
 

--- a/datalad_catalog/tests/test_catalog.py
+++ b/datalad_catalog/tests/test_catalog.py
@@ -23,12 +23,14 @@ from ..catalog import (
 )
 
 
-minimal_metadata = '{' \
-    '   "type": "dataset",' \
-    '   "dataset_id": "0000",' \
-    '   "dataset_version": "000",' \
-    '   "name": "abc"' \
-    '}'
+minimal_metadata = (
+    "{"
+    '   "type": "dataset",'
+    '   "dataset_id": "0000",'
+    '   "dataset_version": "000",'
+    '   "name": "abc"'
+    "}"
+)
 
 default_kwargs = {
     "catalog_dir": ".",
@@ -36,13 +38,10 @@ default_kwargs = {
     "dataset_id": "0000-0000-0000",
     "dataset_version": "abcdef",
     "force": False,
-    "config_file": "catalog.conf"
+    "config_file": "catalog.conf",
 }
 
-result_template = {
-    "status": "ok",
-    "path": "/catalog"
-}
+result_template = {"status": "ok", "path": "/catalog"}
 
 
 def _unwind(
@@ -63,7 +62,9 @@ def test_empty_metadata_detection():
         InsufficientArgumentsError,
         _unwind,
         _validate_metadata,
-        [None,],
+        [
+            None,
+        ],
     )
 
 
@@ -73,7 +74,9 @@ def test_schema_violation_detection(metadata_file: str = ""):
         ValidationError,
         _unwind,
         _validate_metadata,
-        [metadata_file,],
+        [
+            metadata_file,
+        ],
     )
 
 
@@ -85,7 +88,9 @@ def test_metadata_type_mismatch_detection(metadata_file: str = ""):
             ValidationError,
             _unwind,
             _validate_metadata,
-            [metadata_file,],
+            [
+                metadata_file,
+            ],
         )
         assert_in(
             call(
@@ -100,9 +105,7 @@ def test_metadata_type_mismatch_detection(metadata_file: str = ""):
 # TODO: _validate does not validate semantics of dataset_id
 @with_tempfile(content=minimal_metadata)
 def test_proper_validation(metadata_file: str = ""):
-    result = tuple(
-        _validate_metadata(metadata_file)
-    )[0]
+    result = tuple(_validate_metadata(metadata_file))[0]
     assert_equal(result["status"], "ok")
 
 
@@ -110,24 +113,30 @@ def test_proper_validation(metadata_file: str = ""):
 @with_tempfile(content="key: value")
 def test_catalog_action_routing(temp_dir: str = "", config_file: str = ""):
     # expect that every mocked action handler is called
-    with patch("datalad_catalog.catalog._validate_metadata") as f1, \
-            patch("datalad_catalog.catalog._create_catalog") as f2, \
-            patch("datalad_catalog.catalog._serve_catalog") as f3, \
-            patch("datalad_catalog.catalog._add_to_catalog") as f4, \
-            patch("datalad_catalog.catalog._remove_from_catalog") as f5, \
-            patch("datalad_catalog.catalog._set_super_of_catalog") as f6:
+    with patch("datalad_catalog.catalog._validate_metadata") as f1, patch(
+        "datalad_catalog.catalog._create_catalog"
+    ) as f2, patch("datalad_catalog.catalog._serve_catalog") as f3, patch(
+        "datalad_catalog.catalog._add_to_catalog"
+    ) as f4, patch(
+        "datalad_catalog.catalog._remove_from_catalog"
+    ) as f5, patch(
+        "datalad_catalog.catalog._set_super_of_catalog"
+    ) as f6:
 
-        for mock, name in zip((f1, f2, f3, f4, f5, f6),
-                              (f"f{i}" for i in range(1, 7))):
-            mock.return_value = iter([{
-                **result_template,
-                "action": name
-            }])
+        for mock, name in zip(
+            (f1, f2, f3, f4, f5, f6), (f"f{i}" for i in range(1, 7))
+        ):
+            mock.return_value = iter([{**result_template, "action": name}])
 
         results = []
-        for action, create_dir in (("create", False), ("validate", False),
-                                   ("add", True), ("remove", True),
-                                   ("set-super", True), ("serve", True)):
+        for action, create_dir in (
+            ("create", False),
+            ("validate", False),
+            ("add", True),
+            ("remove", True),
+            ("set-super", True),
+            ("serve", True),
+        ):
 
             test_catalog_path = Path(temp_dir) / "test_catalog"
 
@@ -145,15 +154,19 @@ def test_catalog_action_routing(temp_dir: str = "", config_file: str = ""):
                 except FileNotFoundError:
                     pass
 
-            results.append(tuple(
-                Catalog()(**{
-                    **default_kwargs,
-                    "catalog_action": action,
-                    "config_file": config_file,
-                    "catalog_dir": str(Path(temp_dir) / "test_catalog"),
-                    "result_renderer": "disabled"
-                })
-            )[0]["action"])
+            results.append(
+                tuple(
+                    Catalog()(
+                        **{
+                            **default_kwargs,
+                            "catalog_action": action,
+                            "config_file": config_file,
+                            "catalog_dir": str(Path(temp_dir) / "test_catalog"),
+                            "result_renderer": "disabled",
+                        }
+                    )
+                )[0]["action"]
+            )
 
         for i in range(1, 7):
             assert_in(f"f{i}", results)

--- a/datalad_catalog/tests/test_catalog.py
+++ b/datalad_catalog/tests/test_catalog.py
@@ -1,0 +1,89 @@
+from typing import Callable, Dict, List, Optional, Tuple
+from unittest.mock import (
+    call,
+    patch,
+)
+
+from jsonschema.exceptions import ValidationError
+
+from datalad.support.exceptions import InsufficientArgumentsError
+from datalad.tests.utils import (
+    assert_equal,
+    assert_in,
+    assert_raises,
+    with_tempfile,
+)
+
+
+from ..catalog import (
+    _get_line_count,
+    _validate_metadata,
+)
+
+
+def _unwind(
+    function: Callable,
+    args: Optional[List] = None,
+    kwargs: Optional[Dict] = None,
+) -> Tuple:
+    return tuple(function(*(args or []), **(kwargs or {})))
+
+
+@with_tempfile(content="\n".join(map(lambda i: str(i), range(10))))
+def test_line_count(temp_file: str = ""):
+    assert_equal(10, _get_line_count(temp_file))
+
+
+def test_empty_metadata_detection():
+    assert_raises(
+        InsufficientArgumentsError,
+        _unwind,
+        _validate_metadata,
+        [None, None, None, None, False, None],
+    )
+
+
+@with_tempfile(content='{"abc": "xyz"}')
+def test_schema_violation_detection(metadata_file: str = ""):
+    assert_raises(
+        ValidationError,
+        _unwind,
+        _validate_metadata,
+        [None, metadata_file, None, None, False, None],
+    )
+
+
+@with_tempfile(content="[]")
+def test_metadata_type_mismatch_detection(metadata_file: str = ""):
+
+    with patch("datalad_catalog.catalog.lgr") as lgr_mock:
+        assert_raises(
+            ValidationError,
+            _unwind,
+            _validate_metadata,
+            [None, metadata_file, None, None, False, None],
+        )
+        assert_in(
+            call(
+                "Metadata item not of type dict: metadata items should be "
+                "passed to datalad catalog as JSON objects adhering to the "
+                "catalog schema."
+            ),
+            lgr_mock.warning.mock_calls,
+        )
+
+
+# TODO: _validate does not validate semantics of dataset_id
+@with_tempfile(
+    content="{"
+    '   "type": "dataset",'
+    '   "dataset_id": "0000",'
+    '   "dataset_version": "000",'
+    '   "name": "abc"'
+    "}"
+)
+def test_proper_validation(metadata_file: str = ""):
+    result = tuple(
+        _validate_metadata(None, metadata_file, None, None, False, None)
+    )[0]
+    assert_equal(result["status"], "ok")

--- a/datalad_catalog/tests/test_catalog.py
+++ b/datalad_catalog/tests/test_catalog.py
@@ -161,7 +161,7 @@ def test_catalog_action_routing(temp_dir: str = "", config_file: str = ""):
                             **default_kwargs,
                             "catalog_action": action,
                             "config_file": config_file,
-                            "catalog_dir": str(Path(temp_dir) / "test_catalog"),
+                            "catalog_dir": str(test_catalog_path),
                             "result_renderer": "disabled",
                         }
                     )


### PR DESCRIPTION
This PR adds tests for 'datalad_catalog/catalog.py' and refactors `datalad_catalog/catalog.py`, using the tests to verify integrity of the code.

- [x] add tests for all methods in `datalad_catalog/catalog.py`
- [x] refactor `datalad_catalog/catalog.py`