### PR TITLE
FIX: Adjust month in getDateFromUTCSeconds

### DIFF
--- a/datalad_catalog/catalog/assets/vue_app.js
+++ b/datalad_catalog/catalog/assets/vue_app.js
@@ -343,7 +343,7 @@ const datasetView = {
       var d = new Date(0); // epoch date
       d.setUTCSeconds(utcSeconds);
       day = d.getDate();
-      month = d.getMonth();
+      month = d.getMonth() + 1;  // getMonth() returns the month as a zero-based value
       year = d.getFullYear();
       return year + '-' + (month > 9 ? month : '0' + month) + '-' + (day > 9 ? day : '0' + day)
     },


### PR DESCRIPTION
The `Date.prototype.getMonth()` returns a zero-based value ([docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth)), similar to `Date.prototype.getDay()` (day of the week, not used here) but different from `Date.prototype.getDate()` (day of the month, 1-31). So we need to add one to month (but not day and year).

Alternatively, we could get date string with `d.toISOString().substring(0,10)`

Fixes #90 