### PR TITLE
ENH: Orderly create, update, and take down validation progress bars

### DIFF
--- a/datalad_catalog/catalog.py
+++ b/datalad_catalog/catalog.py
@@ -652,16 +652,23 @@ def _validate_metadata(metadata: str):
     # Open metadata file and validate line by line
     with open(metadata) as file:
         i = 0
+        prog_id = "catalogvalidate"
+        log_progress(
+            lgr.info,
+            prog_id,
+            "Validating metadata",
+            unit=" Lines",
+            label="Validating",
+            total=num_lines,
+        )
         for line in file:
             i += 1
             log_progress(
                 lgr.info,
-                "catalogvalidate",
-                f"Start validation of metadata in {metadata}",
-                total=num_lines,
+                prog_id,
+                "Validating metadata",
                 update=i,
-                label="metadata validation against catalog schema",
-                unit=" Lines",
+                noninteractive_level=logging.DEBUG,
             )
             meta_dict = json.loads(line.rstrip())
             # Check if item/line is a dict
@@ -678,6 +685,7 @@ def _validate_metadata(metadata: str):
                     f"Schema validation failed in LINE {i}/{num_lines}: \n\n{e}"
                 )
                 raise ValidationError(err_msg) from e
+        log_progress(lgr.info, prog_id, "Validation completed")
 
     msg = "Metadata successfully validated"
     yield get_status_dict(


### PR DESCRIPTION
Previously, progress bars were neither properly created nor removed
for metadata validation (#136). This change is oriented on
docs.datalad.org/en/latest/design/progress_reporting.html and creates,
updates, and removes the progress bar as outlined in the design docs.
Fixes #136