### PR TITLE
ENH: refactor read+write process of catalog metadata

### DIFF
--- a/datalad_catalog/meta_item.py
+++ b/datalad_catalog/meta_item.py
@@ -57,19 +57,18 @@ class MetaItem(object):
         else:
             # File
             self.process_file(dataset_instance, meta_item)
-            # TODO: confirm what to do if meta_item for file from dataset 
+            # TODO: confirm what to do if meta_item for file from dataset
             # arrives before meta_item for dataset.
             # For now: creating node for dataset, even if via file meta_item.
             # TODO: create cleanup function that removes all dangling node-
             # files, i.e. ones for which the dataset node file does not have
             # any additional metadata other than the id and version
-            
+
     def __call__(self):
         """ """
         pass
 
-    def process_dataset(
-        self, dataset_instance: Node, meta_item: dict):
+    def process_dataset(self, dataset_instance: Node, meta_item: dict):
         """"""
         # 1. If "subdatasets" field exists and the array is not empty,
         # add subdatasets as children and create Nodes
@@ -99,8 +98,7 @@ class MetaItem(object):
         # 2. Add fields to node instance
         dataset_instance.add_attributes(meta_item, overwrite=False)
 
-    def process_file(
-        self, dataset_instance: Node, meta_item: dict):
+    def process_file(self, dataset_instance: Node, meta_item: dict):
         """"""
         #  Create standard node per path part
         f_path = meta_item[cnst.PATH]
@@ -145,7 +143,7 @@ class MetaItem(object):
                     "directory",
                     dataset_instance.dataset_id,
                     dataset_instance.dataset_version,
-                    paths[i - 1]
+                    paths[i - 1],
                 )
                 node_instance.add_child(dir_dict)
             else:
@@ -157,7 +155,7 @@ class MetaItem(object):
                     "directory",
                     dataset_instance.dataset_id,
                     dataset_instance.dataset_version,
-                    paths[i - 1]
+                    paths[i - 1],
                 )
                 node_instance.add_child(meta_item)
 
@@ -192,7 +190,7 @@ class MetaItem(object):
                     "directory",
                     dataset_instance.dataset_id,
                     dataset_instance.dataset_version,
-                    paths[i - 1]
+                    paths[i - 1],
                 )
                 node_instance.add_child(dir_dict)
             else:
@@ -209,7 +207,7 @@ class MetaItem(object):
                     "directory",
                     dataset_instance.dataset_id,
                     dataset_instance.dataset_version,
-                    paths[i - 1]
+                    paths[i - 1],
                 )
                 node_instance.add_child(subds_dict)
 
@@ -221,9 +219,7 @@ class MetaItem(object):
     def getNode(self, catalog, type, dataset_id, dataset_version, path=None):
         """Get existing or create new node"""
         node_hash = md5sum_from_id_version_path(
-            dataset_id,
-            dataset_version,
-            path
+            dataset_id, dataset_version, path
         )
         if node_hash in self._node_instances:
             return self._node_instances[node_hash]

--- a/datalad_catalog/meta_item.py
+++ b/datalad_catalog/meta_item.py
@@ -8,8 +8,7 @@ from datalad_catalog import constants as cnst
 from datalad_catalog.utils import read_json_file
 from datalad_catalog.webcatalog import (
     Node,
-    WebCatalog,
-    getNode,
+    WebCatalog
 )
 
 lgr = logging.getLogger("datalad.catalog.meta_item")
@@ -39,36 +38,37 @@ class MetaItem(object):
         # Get dataset id and version
         d_id = meta_item[cnst.DATASET_ID]
         d_version = meta_item[cnst.DATASET_VERSION]
-        item_type = meta_item[cnst.TYPE]
-        self.metadata = meta_item
+        self._node_instances = {}
         # For both type dataset and type file, we need the dataset Node instance
         # Here we fetch or create this Node instance:
-        dataset_instance = getNode(
-            "dataset", dataset_id=d_id, dataset_version=d_version
+        dataset_instance = Node(
+            catalog=catalog,
+            type="dataset",
+            dataset_id=d_id,
+            dataset_version=d_version,
+            node_path=None,
         )
-        # Set parent catalog of dataset Node instance
-        if (
-            not hasattr(dataset_instance, "parent_catalog")
-            or not dataset_instance.parent_catalog
-        ):
-            dataset_instance.parent_catalog = catalog
+        self._node_instances[dataset_instance.md5_hash] = dataset_instance
         # Then do things based on metadata object type (dataset or file)
         if meta_item[cnst.TYPE] == cnst.TYPE_DATASET:
             # Dataset
-            self.process_dataset(dataset_instance, meta_item, catalog)
+            self.process_dataset(dataset_instance, meta_item)
         else:
             # File
-            # TODO: confirm what to do if meta_item for file from dataset arrives before meta_item for dataset
+            self.process_file(dataset_instance, meta_item)
+            # TODO: confirm what to do if meta_item for file from dataset 
+            # arrives before meta_item for dataset.
             # For now: creating node for dataset, even if via file meta_item.
-            self.process_file(dataset_instance, meta_item, catalog)
-
+            # TODO: create cleanup function that removes all dangling node-
+            # files, i.e. ones for which the dataset node file does not have
+            # any additional metadata other than the id and version
+            
     def __call__(self):
         """ """
         pass
 
     def process_dataset(
-        self, dataset_instance: Node, meta_item: dict, catalog: WebCatalog
-    ):
+        self, dataset_instance: Node, meta_item: dict):
         """"""
         # 1. If "subdatasets" field exists and the array is not empty,
         # add subdatasets as children and create Nodes
@@ -95,15 +95,13 @@ class MetaItem(object):
                         cnst.DATASET_VERSION: subds[cnst.DATASET_VERSION],
                     }
                     dataset_instance.add_child(subds_dict)
-
-        # 2. Add fields to node instance; TODO: handle duplications (overwrite for now)
-        dataset_instance.add_attributes(meta_item, catalog, overwrite=False)
+        # 2. Add fields to node instance
+        dataset_instance.add_attributes(meta_item, overwrite=False)
 
     def process_file(
-        self, dataset_instance: Node, meta_item: dict, catalog: WebCatalog
-    ):
+        self, dataset_instance: Node, meta_item: dict):
         """"""
-        #  Create standard node per path part; TODO: when adding file as child, also add translated_dict
+        #  Create standard node per path part
         f_path = meta_item[cnst.PATH]
         parts_in_path = list(Path(f_path.lstrip("/")).parts)
         nr_parts = len(parts_in_path)
@@ -112,8 +110,6 @@ class MetaItem(object):
         )  # this excludes the last part, which is the actual filename
         incremental_path = Path("")
         paths = []
-        # Assume for now that we're working purely with class instances during operation, then write to file at end
-        # IMPORTANT: this does not account for files that already exist, and their content ==> TODO
         for i, part in enumerate(parts_in_path):
             # Get node path
             incremental_path = incremental_path / part
@@ -136,31 +132,34 @@ class MetaItem(object):
                 meta_item.update(file_dict)
                 dataset_instance.add_child(meta_item)
                 break
-
             # If the file has one or more parent directories
             if i == 0:
                 # first dir in path, add as child to dataset node
                 dataset_instance.add_child(dir_dict)
             elif 0 < i < nr_dirs:
-                # 2nd...(N-1)th dir in path: create node for N-1, add current as child (dir) to node: bv i=1, create node for i=0
-                node_instance = getNode(
-                    "directory",
+                # 2nd...(N-1)th dir in path: create node for N-1,
+                # add current as child (dir) to node: bv i=1, create node for i=0
+                node_instance = Node(
+                    catalog=dataset_instance.parent_catalog,
+                    type="directory",
                     dataset_id=dataset_instance.dataset_id,
                     dataset_version=dataset_instance.dataset_version,
-                    path=paths[i - 1],
+                    node_path=paths[i - 1],
                 )
-                node_instance.parent_catalog = catalog
+                self._node_instances[node_instance.md5_hash] = node_instance
                 node_instance.add_child(dir_dict)
             else:
-                # Nth (last) part in path = file: create node for N-1, add current as child (file) to node
+                # Nth (last) part in path = file: create node for N-1,
+                # add current as child (file) to node
                 meta_item.update(file_dict)
-                node_instance = getNode(
-                    "directory",
+                node_instance = Node(
+                    catalog=dataset_instance.parent_catalog,
+                    type="directory",
                     dataset_id=dataset_instance.dataset_id,
                     dataset_version=dataset_instance.dataset_version,
-                    path=paths[i - 1],
+                    node_path=paths[i - 1],
                 )
-                node_instance.parent_catalog = catalog
+                self._node_instances[node_instance.md5_hash] = node_instance
                 node_instance.add_child(meta_item)
 
     def subdataset_path_to_nodes(
@@ -174,7 +173,6 @@ class MetaItem(object):
         nr_parts = len(parts_in_path)
         incremental_path = Path("")
         paths = []
-        # IMPORTANT: this does not account for files that already exist, and their content ==> TODO
         for i, part in enumerate(parts_in_path):
             # Create dictionary of type directory
             incremental_path = incremental_path / part
@@ -188,14 +186,17 @@ class MetaItem(object):
                 # first dir in path, add as child to dataset node
                 dataset_instance.add_child(dir_dict)
             elif i < nr_parts - 1:
-                # 2nd...(N-1)th dir in path: create node for N-1, add current as child (dir) to node: e.g. i=1, create node for i=0
+                # 2nd...(N-1)th dir in path: create node for N-1,
+                # add current as child (dir) to node: e.g. i=1, create node for i=0
                 # path for i: parent_dirs[nr_parts-1-i]
-                node_instance = getNode(
-                    "directory",
+                node_instance = Node(
+                    catalog=dataset_instance.parent_catalog,
+                    type="directory",
                     dataset_id=dataset_instance.dataset_id,
                     dataset_version=dataset_instance.dataset_version,
-                    path=paths[i - 1],
+                    node_path=paths[i - 1],
                 )
+                self._node_instances[node_instance.md5_hash] = node_instance
                 node_instance.add_child(dir_dict)
             else:
                 # Nth (last) part in path = sub-dataset: create node for N-1, add current as child (dataset) to node
@@ -206,10 +207,20 @@ class MetaItem(object):
                     cnst.DATASET_ID: subds_id,
                     cnst.DATASET_VERSION: subds_version,
                 }
-                node_instance = getNode(
-                    "dataset",
+                node_instance = Node(
+                    catalog=dataset_instance.parent_catalog,
+                    type="dataset",
                     dataset_id=dataset_instance.dataset_id,
                     dataset_version=dataset_instance.dataset_version,
-                    path=paths[i - 1],
+                    node_path=paths[i - 1],
                 )
+                self._node_instances[node_instance.md5_hash] = node_instance
                 node_instance.add_child(subds_dict)
+
+    def write_nodes_to_files(self):
+        """"""
+        for n in self._node_instances.values():
+            n.write_attributes_to_file()
+
+
+

--- a/datalad_catalog/tests/test_multisource.py
+++ b/datalad_catalog/tests/test_multisource.py
@@ -8,20 +8,25 @@ from datalad_catalog.webcatalog import (
 
 
 @pytest.fixture
-def demo_node_dataset():
-    test_ds_id = "5df8eb3a-95c5-11ea-b4b9-a0369f287950"
-    test_ds_version = "dae38cf901995aace0dde5346515a0134f919523"
-    test_type = "dataset"
-    Node._split_dir_length = 3
-    return Node(
-        type=test_type, dataset_id=test_ds_id, dataset_version=test_ds_version
-    )
-
-
-@pytest.fixture
 def demo_catalog(tmp_path):
     catalog_path = tmp_path / "test_catalog"
     return WebCatalog(location=catalog_path)
+
+
+@pytest.fixture
+def demo_node_dataset(demo_catalog):
+    test_ds_id = "5df8eb3a-95c5-11ea-b4b9-a0369f287950"
+    test_ds_version = "dae38cf901995aace0dde5346515a0134f919523"
+    test_type = "dataset"
+    test_path = None
+    Node._split_dir_length = 3
+    return Node(
+        catalog=demo_catalog,
+        type=test_type,
+        dataset_id=test_ds_id,
+        dataset_version=test_ds_version,
+        node_path=test_path,
+    )
 
 
 @pytest.fixture

--- a/datalad_catalog/tests/test_node.py
+++ b/datalad_catalog/tests/test_node.py
@@ -4,10 +4,7 @@ import hashlib
 import pytest
 
 from datalad_catalog import constants as cnst
-from datalad_catalog.webcatalog import (
-    Node,
-    WebCatalog
-)
+from datalad_catalog.webcatalog import Node, WebCatalog
 
 
 @pytest.fixture

--- a/datalad_catalog/tests/test_node.py
+++ b/datalad_catalog/tests/test_node.py
@@ -1,3 +1,4 @@
+from cgi import test
 import hashlib
 
 import pytest
@@ -5,35 +6,8 @@ import pytest
 from datalad_catalog import constants as cnst
 from datalad_catalog.webcatalog import (
     Node,
-    WebCatalog,
-    getNode,
+    WebCatalog
 )
-
-
-@pytest.fixture
-def demo_node_dataset():
-    test_ds_id = "5df8eb3a-95c5-11ea-b4b9-a0369f287950"
-    test_ds_version = "dae38cf901995aace0dde5346515a0134f919523"
-    test_type = "dataset"
-    Node._split_dir_length = 3
-    return Node(
-        type=test_type, dataset_id=test_ds_id, dataset_version=test_ds_version
-    )
-
-
-@pytest.fixture
-def demo_node_directory():
-    test_ds_id = "5df8eb3a-95c5-11ea-b4b9-a0369f287950"
-    test_ds_version = "dae38cf901995aace0dde5346515a0134f919523"
-    test_type = "directory"
-    dir_path = "dir1/dir2"
-    Node._split_dir_length = 3
-    return Node(
-        type=test_type,
-        dataset_id=test_ds_id,
-        dataset_version=test_ds_version,
-        node_path=dir_path,
-    )
 
 
 @pytest.fixture
@@ -42,18 +16,36 @@ def demo_catalog(tmp_path):
     return WebCatalog(location=catalog_path)
 
 
-def test_node_instances_equal():
-    """
-    Assert that two instances with identical variables, one created via class
-    instantiation and one created via getNode method, are the same object
-    """
-    node_instance_1 = Node(
-        type="dataset", dataset_id="123", dataset_version="v1"
+@pytest.fixture
+def demo_node_dataset(demo_catalog):
+    test_ds_id = "5df8eb3a-95c5-11ea-b4b9-a0369f287950"
+    test_ds_version = "dae38cf901995aace0dde5346515a0134f919523"
+    test_type = "dataset"
+    test_path = None
+    Node._split_dir_length = 3
+    return Node(
+        catalog=demo_catalog,
+        type=test_type,
+        dataset_id=test_ds_id,
+        dataset_version=test_ds_version,
+        node_path=test_path,
     )
-    node_instance_2 = getNode(
-        type="dataset", dataset_id="123", dataset_version="v1"
+
+
+@pytest.fixture
+def demo_node_directory(demo_catalog):
+    test_ds_id = "5df8eb3a-95c5-11ea-b4b9-a0369f287950"
+    test_ds_version = "dae38cf901995aace0dde5346515a0134f919523"
+    test_type = "directory"
+    dir_path = "dir1/dir2"
+    Node._split_dir_length = 3
+    return Node(
+        catalog=demo_catalog,
+        type=test_type,
+        dataset_id=test_ds_id,
+        dataset_version=test_ds_version,
+        node_path=dir_path,
     )
-    assert node_instance_1 == node_instance_2
 
 
 def test_md5hash():

--- a/datalad_catalog/tests/test_translate.py
+++ b/datalad_catalog/tests/test_translate.py
@@ -11,17 +11,10 @@ from datalad_catalog.utils import read_json_file
 from datalad_catalog.webcatalog import (
     Node,
     WebCatalog,
-    getNode,
 )
 
 tests_path = Path(__file__).resolve().parent
 data_path = tests_path / "data"
-
-
-@pytest.fixture
-def demo_metadata_item():
-    metadata_path = data_path / "catalog_metadata_dataset.json"
-    return read_json_file(metadata_path)
 
 
 @pytest.fixture
@@ -30,22 +23,28 @@ def demo_catalog(tmp_path):
     return WebCatalog(location=catalog_path)
 
 
-def test_translate_dataset(demo_metadata_item: dict, demo_catalog: WebCatalog):
-    """ """
-    Node._instances = {}
+@pytest.fixture
+def demo_metadata_item():
+    metadata_path = data_path / "catalog_metadata_dataset.json"
+    return read_json_file(metadata_path)
+
+
+def test_translate_dataset(demo_catalog: WebCatalog, demo_metadata_item: dict):
+    """"""
     demo_catalog.config = {"property_source": {"dataset": {}}}
     metatest = MetaItem(demo_catalog, demo_metadata_item)
-    assert len(Node._instances) == 1
+    assert len(metatest._node_instances) == 1
     new_node = [
-        Node._instances[n]
-        for n in Node._instances
-        if Node._instances[n].dataset_id == demo_metadata_item[cnst.DATASET_ID]
-        and Node._instances[n].dataset_version
+        metatest._node_instances[n]
+        for n in metatest._node_instances
+        if metatest._node_instances[n].dataset_id
+        == demo_metadata_item[cnst.DATASET_ID]
+        and metatest._node_instances[n].dataset_version
         == demo_metadata_item[cnst.DATASET_VERSION]
     ]
     assert len(new_node) == 1
     fn = new_node[0].get_location()
-    new_node[0].write_to_file()
+    new_node[0].write_attributes_to_file()
     translated_metadata = read_json_file(fn)
     for key in translated_metadata:
         if not bool(translated_metadata[key]):

--- a/datalad_catalog/webcatalog.py
+++ b/datalad_catalog/webcatalog.py
@@ -230,10 +230,10 @@ class Node(object):
         self.node_path = node_path
         self.long_name = self.get_long_name()
         self.md5_hash = self.md5hash(self.long_name)
+        self.children = []
         # If corresponding file exists, set attributes
         if self.is_created():
             self.set_attributes_from_file()
-        self.children = []
 
     def is_created(self) -> bool:
         """
@@ -291,6 +291,7 @@ class Node(object):
         metadata = self.load_file()
         for key in metadata.keys():
             setattr(self, key, metadata[key])
+
 
     def get_long_name(self):
         """
@@ -535,3 +536,11 @@ def copy_overwrite_path(src: Path, dest: Path, overwrite: bool = False):
             if dest.exists():
                 shutil.rmtree(dest)
             shutil.copytree(src, dest)
+
+
+def md5sum_from_id_version_path(dataset_id, dataset_version, path=None):
+    """Helper to get md5 hash of concatenated input variables"""
+    long_name = dataset_id + "-" + dataset_version
+    if path:
+        long_name = long_name + "-" + str(path)
+    return hashlib.md5(long_name.encode("utf-8")).hexdigest()

--- a/datalad_catalog/webcatalog.py
+++ b/datalad_catalog/webcatalog.py
@@ -34,6 +34,7 @@ class WebCatalog(object):
     """
     The main catalog class.
     """
+
     # Get package-related paths
     package_path = Path(__file__).resolve().parent
     config_dir = package_path / "config"
@@ -271,8 +272,7 @@ class Node(object):
             json.dump(meta_dict, f)
 
     def load_file(self):
-        """Load content from catalog metadata file for current node
-        """
+        """Load content from catalog metadata file for current node"""
         try:
             with open(self.get_location()) as f:
                 return json.load(f)
@@ -291,7 +291,6 @@ class Node(object):
         metadata = self.load_file()
         for key in metadata.keys():
             setattr(self, key, metadata[key])
-
 
     def get_long_name(self):
         """
@@ -348,12 +347,12 @@ class Node(object):
         path_right = dir_name[self._split_dir_length :]
         return path_left, path_right
 
-    def add_attributes(
-        self, new_attributes: dict, overwrite=False
-    ):
+    def add_attributes(self, new_attributes: dict, overwrite=False):
         """Add attributes (key-value pairs) to a Node as instance variables"""
         # Get config
-        dataset_config = self.parent_catalog.config[cnst.PROPERTY_SOURCE][cnst.TYPE_DATASET]
+        dataset_config = self.parent_catalog.config[cnst.PROPERTY_SOURCE][
+            cnst.TYPE_DATASET
+        ]
         # Get extractor / source. TODO: rework the extractors_used property, see https://github.com/datalad/datalad-catalog/issues/68
         try:
             data_source = new_attributes[cnst.EXTRACTORS_USED][0][


### PR DESCRIPTION
This PR addresses #168 and #169.

It refactors the code in multiple modules related to how and when metadata is read from and written to target files in a catalog. Main changes include:
- The `MetaItem` class, responsible for translating an incoming json line metadata item into catalog metadata consisting of one or multiple `Node`s (each with a corresponding json file), can be the parent of multiple `Node` instances.
- New functionality for (1) creating a new node if the corresponding file does not yet exist, and (2) reading a node's attributes from file if the file already exists. This is done whenever the `Node` class is instantiated.
- At the end of processing a single `MetaItem` instance, its children nodes are written to file, instead of all nodes being written to file at the end of processing all lines in an incoming metadata file (as was done previously)
- Moved all of this functionality into the relevant modules and out of the `Catalog` interface module