### PR TITLE
ENH: add conftest to use datalad core setup_package fixture

### DIFF
--- a/datalad_catalog/conftest.py
+++ b/datalad_catalog/conftest.py
@@ -1,0 +1,1 @@
+from datalad.conftest import setup_package


### PR DESCRIPTION
While working with @mslw desiring to use a fixture with custom
~/.gitconfig we discovered that datalad-catalog does not have
conftest at all so the datalad global fixture is not used and there is
no custom git user.{email,name}.  With this we should get it
consistent and use datalad's fixture. Taken from

https://github.com/datalad/datalad-extension-template/pull/35/files