### PR TITLE
Adds test data to package_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.2 (Fri Sept 16 2022) -- red tests
+
+#### 🛡 Tests
+- Adds test data to package_data to ensure availability when installing from pip with extras [#199](https://github.com/datalad/datalad-catalog/pull/199) (by @jsheunis)
+
+#### Authors: 1
+
+- Stephan Heunis (@jsheunis)
+
+---
+
 # 0.1.1 (Tue Sept 13 2022) -- release continued
 
 #### 💫 Enhancements and new features

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 include_package_data = True
 
 [options.package_data]
-* = catalog/*, catalog/artwork/*, catalog/assets/*, catalog/assets/favicon/*, catalog/metadata/*, config/*, schema/*
+* = catalog/*, catalog/artwork/*, catalog/assets/*, catalog/assets/favicon/*, catalog/metadata/*, config/*, schema/*, tests/data/*
 
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups


### PR DESCRIPTION
To address `FileNotFoundError` and related errors in `datalad-extensions` workflow runs, see https://github.com/datalad/datalad-catalog/issues/198.