### PR TITLE
ENH: handling of unavailable subdatasets in file browser

### DIFF
--- a/datalad_catalog/catalog/assets/style.css
+++ b/datalad_catalog/catalog/assets/style.css
@@ -65,10 +65,12 @@ body {
 .subdataset {
   color: var(--link-color);
   text-decoration: underline;
-
 }
 .subdataset:hover {
   color: var(--link-hover-color);
+}
+.subdataset-disabled {
+  color: rgb(172, 172, 172);
 }
 
 .newlink {

--- a/datalad_catalog/catalog/index.html
+++ b/datalad_catalog/catalog/index.html
@@ -32,7 +32,7 @@
         <div :class="{bold: isFolder}" @click="toggle">
           <span v-if="isFolder && isOpen"> <i class="far fa-folder-open"></i> {{ displayText }}</span>
           <span v-else-if="isFolder && !isOpen"> <i class="far fa-folder"></i> {{ displayText }}</span>
-          <span v-else-if="isDataset"> <i class="fas fa-database"></i> <a class="subdataset" @click="selectDataset(item, item.id)">{{ displayText }}</a></span>
+          <span v-else-if="isDataset"><span v-if="item.state == 'disabled'" class="subdataset-disabled"> <i class="fas fa-database"></i> {{ displayText }}</span><span v-else> <i class="fas fa-database"></i> <a class="subdataset" @click="selectDataset(item, item.id)">{{ displayText }}</a></span></span>
           <!-- <span v-else> <i class="far fa-file-alt"></i> {{ displayText }} <span v-show="downloadURL"><a class="xsm-dl-button" :href="downloadURL" :download="displayText"><i class="fa fa-cloud-download" aria-hidden="true"></i></a></span><span class="filesize"><i class="fa fa-eye" aria-hidden="true"></i>{{byteText}}</span> </span> -->
           <span v-else> <i class="far fa-file-alt"></i> {{ displayText }} <span class="filesize"><span v-show="downloadURL"><a class="xsm-dl-button" :href="downloadURL" :download="displayText"><i class="fas fa-cloud-download" aria-hidden="true"></i></a></span>{{byteText}}</span> </span>
         </div>


### PR DESCRIPTION
This PR closes #44 and #52.

The main decisions and implementations:
- in the subdatasets view: keep the listed subdatasets as they are, i.e. only list the subdatasets that are also available in the same catalog (no changes made here)
- in the file tree view: keep and display the unavailable subdatasets, but grey them out (changed). These items are not clickable anymore and hence there is no need to show a popup for unavailable subdatasets (unless subdataset metadata that *should* be available in the catalog is not available for some other reason)