### PR TITLE
Adds simplistic demo for metadata entry

### DIFF
--- a/datalad_catalog/catalog/assets/meta_entry.js
+++ b/datalad_catalog/catalog/assets/meta_entry.js
@@ -1,0 +1,102 @@
+/********/
+// Data //
+/********/
+const default_config = {
+  catalog_name: "DataCat",
+  link_color: "#fba304",
+  link_hover_color: "#af7714",
+};
+
+/**************/
+// Components //
+/**************/
+
+/***********/
+// Vue app //
+/***********/
+
+// Start Vue instance
+var demo = new Vue({
+  el: "#meta-entry",
+  data: {
+    metaTabIndex: {},
+    dataset_name: "",
+    dataset_description: "",
+    logo_path: "artwork/catalog_logo.svg",
+    form: {
+      name: '',
+      description: '',
+      url: '',
+      doi: '',
+      dataset_id: '',
+      dataset_version: '',
+      keywords: [],
+    },
+    show: true
+  },
+  methods: {
+    gotoHome() {
+      router.push({ name: "home" });
+    },
+    gotoAbout() {
+      router.push({ name: "about" });
+    },
+    gotoExternal(dest) {
+      const destinations = {
+        github:
+          "https://github.com/datalad/datalad-catalog",
+        docs: "https://docs.datalad.org/projects/catalog/en/latest/",
+        twitter: "https://twitter.com/datalad",
+      };
+      if (dest in destinations) {
+        window.open(destinations[dest]);
+      } else {
+        window.open(dest);
+      }
+    },
+    onSubmit(event) {
+      event.preventDefault()
+      downloadObjectAsJson(this.form, 'dataset_info.json')
+      // alert(JSON.stringify(this.form))
+    },
+    onReset(event) {
+      event.preventDefault()
+      // Reset our form values
+      this.form.name = '',
+      this.form.description = '',
+      this.form.url = '',
+      this.form.doi = '',
+      // Trick to reset/clear native browser form validation state
+      this.show = false
+      this.$nextTick(() => {
+        this.show = true
+      })
+    }
+  },
+  beforeCreate() {
+    // Set color scheme
+    const style_text =
+    ":root{--link-color: " +
+    default_config.link_color +
+    "; --link-hover-color: " +
+    default_config.link_hover_color +
+    ";}";
+    const style_section = document.createElement("style");
+    const node = document.createTextNode(style_text);
+    style_section.appendChild(node);
+    const body_element = document.getElementById("mainmetabody");
+    body_element.insertBefore(style_section, body_element.firstChild);
+    // Set logo
+    // this.logo_path = default_config.logo_path;
+  },
+});
+
+function downloadObjectAsJson(obj, filename){
+  var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(obj));
+  var downloadAnchorNode = document.createElement('a');
+  downloadAnchorNode.setAttribute("href",     dataStr);
+  downloadAnchorNode.setAttribute("download", filename + ".json");
+  document.body.appendChild(downloadAnchorNode);
+  downloadAnchorNode.click();
+  downloadAnchorNode.remove();
+}

--- a/datalad_catalog/catalog/assets/style.css
+++ b/datalad_catalog/catalog/assets/style.css
@@ -154,3 +154,8 @@ li[class="item"]:nth-child(odd) {
   border: 1px solid #444;
   border-radius: 5px;
 }
+
+
+.form-group {
+  margin-top: 1em;
+}

--- a/datalad_catalog/catalog/metadata-entry.html
+++ b/datalad_catalog/catalog/metadata-entry.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+
+    <link rel="icon" href="assets/favicon/favicon.ico" type="image/x-icon">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon/favicon-16x16.png">
+
+    <title>DataLad Catalog Metadata</title>
+
+    <!-- Required Stylesheets -->
+    <link rel="stylesheet" type="text/css" href="assets/style.css"/>
+    <link rel="stylesheet" type="text/css" href="assets/fontawesome.min.css"/>
+    <link rel="stylesheet" type="text/css" href="assets/brands.min.css"/>
+    <link type="text/css" rel="stylesheet" href="assets/bootstrap.5.1.3.min.css"/>
+    <link type="text/css" rel="stylesheet" href="assets/bootstrap-vue.2.21.2.min.css"/>
+
+    <!-- Required scripts -->
+    <script src="assets/vue.2.6.14.min.js"></script>
+    <script src="assets/bootstrap-vue.2.21.2.min.js"></script>
+    <script src="assets/vue-router.3.5.3.min.js"></script>
+
+
+
+
+
+  <!-- ### -->
+  <!-- ### -->
+  <!-- ### -->
+  <body id="mainmetabody">
+    <!-- Our application root element -->
+    <b-container id="meta-entry" >
+      <b-container style="margin-top:20px;">
+        <b-row align-v="end">
+          <b-col cols="9">
+            <span v-show="logo_path"><a @click="gotoHome"><img :src="logo_path" class="d-inline-block" alt="datalad" style="width:100%;"></a></span>
+          </b-col>
+          <b-col cols="1"></b-col>
+          <b-col cols="2" align-h="end">
+            <b-navbar toggleable="lg" type="light" variant="outline-dark">
+          
+              <b-navbar-toggle target="navbar-toggle-collapse">
+              </b-navbar-toggle>
+              <b-collapse id="navbar-toggle-collapse" is-nav>
+                <b-navbar-nav class="ml-auto mb-0 xlfont">
+                  <b-nav-item v-b-tooltip.hover title="About" @click="gotoAbout"><i class="fas fa-info-circle"></i></b-nav-item>
+                  <b-nav-item v-b-tooltip.hover title="Read documentation" @click="gotoExternal('docs')"><i class="fas fa-file-alt"></i></b-nav-item>
+                  <b-nav-item v-b-tooltip.hover title="View code base" @click="gotoExternal('github')"><i class="fab fa-github"></i></b-nav-item>
+                  <b-nav-item v-b-tooltip.hover title="Follow DataLad!" @click="gotoExternal('twitter')"><i class="fab fa-twitter"></i></b-nav-item>
+                </b-navbar-nav>
+              </b-collapse>
+            </b-navbar>
+          </b-col>
+        </b-row>
+      </b-container>
+      <br>
+      <div>
+        <br>
+        <h2 style="text-align: center;" >Metadata entry form</h2>
+        <br>
+        <b-tabs card content-class="mt-3" fill active-nav-item-class="font-weight-bold" v-model="metaTabIndex">
+          <b-tab>
+            <template v-slot:title>
+              <i class="far fa-folder-open"></i> Dataset
+            </template>
+
+            <b-form @submit="onSubmit" @reset="onReset" v-if="show">
+
+              <b-form-group id="input-group-1" label="Name:" label-for="input-1" description="The name of your dataset">
+                <b-form-input id="input-1" v-model="form.name" placeholder="e.g. neuroimaging-study" required></b-form-input>
+              </b-form-group>
+
+              <b-form-group id="input-group-2" label="Description:" label-for="input-2" description="A 1-2 paragraph free-form description of your dataset">
+                <b-form-textarea id="input-2" v-model="form.description" placeholder="Lorem ipsum dolor sit amet, consectetur..." rows=4 required></b-form-input>
+              </b-form-group>
+        
+              <b-form-group id="input-group-3" label="URL:" label-for="input-3" description="The URL at which your dataset is accessible">
+                <b-form-input id="input-3" v-model="form.url" placeholder="e.g. 'https://www.github.com/psychoinformatics-de/fairly-big-processing-workflow'"></b-form-input>
+              </b-form-group>
+
+              <b-form-group id="input-group-4" label="DOI:" label-for="input-4" description="The digital object identifier of your dataset">
+                <b-form-input id="input-4" v-model="form.doi" placeholder="e.g. 'https://doi.org/10.5281/zenodo.6019782'"></b-form-input>
+              </b-form-group>
+
+              <!-- <b-form-group label-for="tags-basic" label="Tags:" label-for=""tags-basic>
+                  <b-form-tags id="tags-basic" v-model="form.keywords" tag-variant="outline-dark" tag-pills></b-form-tags>
+              </b-form-group> -->
+
+              <br><br>
+              <b-button type="submit" variant="outline-dark"><i class="fas fa-download"></i> Save metadata</b-button>&nbsp;
+              <!-- <b-button type="submit" variant="primary">Submit</b-button> -->
+              <b-button type="reset" variant="outline-dark"><i class="fas fa-xmark"></i> Reset</b-button>
+            </b-form>
+            <b-card class="mt-3" header="Form Data Result">
+              <pre class="m-0">{{ form }}</pre>
+            </b-card>
+            <!-- <b-container>
+              <b-row align-v="end">
+                <b-col cols="9">
+                  <p>Name:</p>
+                  <input v-model="dataset_name" placeholder="The name of your dataset" />
+                  <br><br>
+                  <p>Description:</p>
+                  <textarea v-model="dataset_description" placeholder="Add a 1-2 paragraph description of your dataset"></textarea>
+                </b-col>
+              </b-row>
+            </b-container> -->
+
+          </b-tab>
+          <b-tab>
+            <template v-slot:title>
+              <i class="fas fa-file-alt"></i> File
+            </template>
+          </b-tab>
+        </b-tabs>
+      </div> 
+    </b-container>
+
+    <b-container>
+      <br>
+      <br>
+      <br>
+      <br>
+    </b-container>
+
+    <!-- Start running your app -->
+    <script src="assets/meta_entry.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
The point is to have a (currently hidden) page on which users can enter metadata. This content then populates fields on an object, and the object is downloaded as a json file upon submit.

In future, this functionality can be extended to generate form fields automatically from a schema.