### PR TITLE
NF: Render a human-readable json schema definition

### DIFF
--- a/datalad_catalog/catalog/assets/display_schema.js
+++ b/datalad_catalog/catalog/assets/display_schema.js
@@ -1,0 +1,440 @@
+/**************/
+// Components //
+/**************/
+
+const schema_file = "./assets/jsonschema_dataset.json";
+
+schema_keywords = ["$schema", "$id"]
+instance_keywords = ["type"]
+schema_annotations = ["title", "description", "default", "examples", "readOnly", "writeOnly", "deprecated"]
+additional_schema_keywords = ["$ref", "$defs"]
+validation_keywords = ["properties", "additionalProperties", "required", "items", "multipleOf", "maximum", "minimum", "exclusiveMaximum", "exclusiveMinimum", "minItems", "maxItems", "uniqueItems"]
+
+validation_keywords = {
+  any: {
+    type: ["string", "array"],
+    enum: "array",
+    const: "any",
+  },
+  number: {
+    multipleOf: "number",
+    maximum: "number",
+    minimum: "number",
+    exclusiveMaximum: "number",
+    exclusiveMinimum: "number",
+  },
+  integer: {
+    multipleOf: "number",
+    maximum: "number",
+    minimum: "number",
+    exclusiveMaximum: "number",
+    exclusiveMinimum: "number",
+  },
+  string: {
+    minLength: "integer",
+    maxLength: "integer",
+    pattern: "string",
+    format: "string"
+  },
+  array: {
+    minItems: "integer",
+    minItems: "integer",
+    uniqueItems: "boolean",
+    maxContains: "integer",
+    minContains: "integer",
+  },
+  object: {
+    maxProperties: "integer",
+    minProperties: "integer",
+    dependentRequired: "object",
+  },
+}
+
+
+// top_level_fields = {
+//   "$schema": "string",
+//   "$id": "string",
+//   "$comment": "string",
+//   "$ref": "string",
+//   "type": ["string", "array"],
+//   "title": "string",
+//   "description": "string",
+//   "default": "any",
+//   "examples": "array",
+//   "readOnly": "boolean",
+//   "writeOnly": "boolean",
+//   "deprecated": "boolean",
+//   "enum": "array",
+//   "const": "any",
+//   "required": "array"
+// }
+
+const types =  [
+  "string",
+  "number",
+  "integer",
+  "object",
+  "array",
+  "boolean",
+  "null",
+]
+
+format = [
+  "date-time",
+  "time",
+  "date",
+  "duration",
+  "email",
+  "idn-email",
+  "hostname",
+  "idn-hostname",
+  "ipv4",
+  "ipv6",
+  "uuid",
+  "uri",
+  "uri-reference",
+  "iri",
+  "iri-reference",
+  "uri-template",
+  "json-pointer",
+  "relative-json-pointer",
+  "regex",
+]
+
+defaults = {
+  schema_keywords: schema_keywords,
+  instance_keywords: instance_keywords,
+  schema_annotations: schema_annotations,
+  additional_keywords: additional_schema_keywords,
+  validation_keywords: validation_keywords,
+}
+
+const INPUT_TYPES = [
+  'text',
+  'password',
+  'email',
+  'number',
+  'url',
+  'tel',
+  'search',
+  'date',
+  'datetime',
+  'datetime-local',
+  'month',
+  'week',
+  'time',
+  'range',
+  'color'
+]
+
+type_icons = {
+  "string": "““",
+  "number": ".5",
+  "integer": "12",
+  "object": "{}",
+  "array": "[]",
+  "boolean": "01",
+  "null": "--",
+  "$ref": "->",
+}
+
+type_colors = {
+  "string": "#fd7e14", // orange
+  "number": "#007bff", // blue
+  "integer": "#28a745", // green
+  "object": "#e83e8c", // pink
+  "array": "#20c997", // teal
+  "boolean": "#6610f2", // indigo
+  "null": "#6f42c1", // purple
+  "$ref": "#17a2b8" //  cyan
+}
+
+// required: red
+// optional: orange
+
+// $blue: #007bff !default;
+// $indigo: #6610f2 !default;
+// $purple: #6f42c1 !default;
+// $pink: #e83e8c !default;
+// $red: #dc3545 !default;
+// $orange: #fd7e14 !default;
+// $yellow: #ffc107 !default;
+// $green: #28a745 !default;
+// $teal: #20c997 !default;
+// $cyan: #17a2b8 !default;
+
+
+
+Vue.component("t-custom-input", {
+  template: "#custom-input-template",
+  props: [
+    'value'
+  ],
+})
+
+Vue.component("schema-item", {
+  template: "#schema-item",
+  props: [
+    'name',
+    'item',
+    'defaults',
+    'requireditems',
+  ],
+  data: function () {
+    return {
+      type_icons: type_icons,
+      type_colors: type_colors,
+    }
+  },
+  computed: {
+    hasvalidations() {
+      var i = 0, type_arr, key_arr;
+      if ('type' in this.item) {
+        type_arr = Array.isArray(this.item.type) ? this.item.type : [this.item.type]
+        console.log(type_arr)
+        for (var tp=0; tp<type_arr.length; tp++) {
+          key_arr = Object.keys(this.defaults.validation_keywords[type_arr[tp]])
+          for (var kw=0; kw<key_arr.length; kw++) {
+            console.log(key_arr[kw])
+            if (key_arr[kw] in this.item) {
+              i+=1;
+            }
+          }
+        }
+      }
+      return (i > 0 ? true : false)
+    }
+  }
+})
+
+
+Vue.component("t-input", {
+  template: "#input-template",
+  data: function () {
+    return {
+      inputTypes: INPUT_TYPES,
+      edited_item: {},
+      edit_existing: null,
+      edit_index: null,
+    }
+  },
+  props: [
+    'obj',
+    'defs'
+  ],
+  methods: {
+    removeItemModal(idx) {
+      console.log(idx)
+      this.$bvModal.msgBoxConfirm('This will delete the row from your metadata, are you sure you want to continue?.', {
+        title: 'Please Confirm',
+        size: 'sm',
+        buttonSize: 'sm',
+        okVariant: 'danger',
+        okTitle: 'DELETE',
+        cancelTitle: 'Cancel',
+        footerClass: 'p-2',
+        hideHeaderClose: true,
+        centered: true
+      })
+        .then(value => {
+          if (value) {
+            this.obj.value.splice(idx, 1)
+          }
+        })
+        .catch(err => {
+          // An error occurred
+        })
+    },
+    addItemModal(idx, def) {
+      this.edited_item = {}
+      this.edit_existing = false
+      if (Number.isFinite(idx)) {
+        this.edit_index = idx
+        this.edit_existing = true
+        this.edited_item = JSON.parse(JSON.stringify(this.obj.value[idx]))
+      }
+      else {
+        key_list = def.fields.map(f => 
+          this.edited_item[f.name] = "")
+      }
+      this.$refs['additem'].show()
+    },
+    saveItem() {
+      if (this.edit_existing) {
+        this.obj.value[this.edit_index] = JSON.parse(JSON.stringify(this.edited_item))
+      }
+      else {
+        this.obj.value.push(this.edited_item)
+      }
+      this.edited_item = {}
+      this.edit_existing = null
+      this.edit_index = null
+      this.$refs['itemtable'].refresh()
+    }
+
+  },
+  computed: {
+    state() {
+      return this.obj.value.length == 4
+    },
+    // invalidFeedback() {
+    //   if (this.obj.value.length > 0) {
+    //     return 'Enter at least 4 characters.'
+    //   }
+    //   return 'Please enter something.'
+    // }
+  },
+})
+
+
+/***********/
+// Vue app //
+/***********/
+
+// Start Vue instance
+var form_app = new Vue({
+  el: "#vue_app",
+  data: {
+    schema_files: [schema_file],
+    schema: {},
+    defaults: defaults,
+    searchText: "",
+    headingText: "kaas",
+    inputTypes: INPUT_TYPES,
+    inputData: [
+      {
+        description: "The name of your dataset",
+        input_id: "input-2",
+        input_group_id: "input-group-2",
+        label: "Name",
+        required: true,
+        form_field: "name",
+        placeholder: "placeholder2",
+        input_type: "text",
+        value: "",
+
+      },
+      {
+        description: "The description of your dataset",
+        input_id: "input-1",
+        input_group_id: "input-group-1",
+        label: "Description",
+        required: true,
+        form_field: "description",
+        placeholder: "placeholder1",
+        input_type: "textarea",
+        value: "",
+      },
+      {
+        description: "The URL of your dataset",
+        input_id: "input-3",
+        input_group_id: "input-group-3",
+        label: "URL",
+        required: false,
+        form_field: "url",
+        placeholder: "placeholder3",
+        input_type: "url",
+        value: "",
+      },
+      {
+        description: "Dataset authors",
+        input_id: "input-4",
+        input_group_id: "input-group-4",
+        label: "Authors",
+        required: false,
+        form_field: "authors",
+        placeholder: "placeholder4",
+        input_type: "array",
+        value: [
+          {
+            name: "Stephan",
+            lastname: "Heunis"
+          },
+          {
+            name: "Stephan2",
+            lastname: "Heunis2"
+          },
+
+        ],
+        item_def: "author"
+      }
+    ],
+    definitions: [
+      {
+        name: "author",
+        fields: [
+          {
+            name: "name",
+            type: String,
+            required: true
+          },
+          {
+            name: "lastname",
+            type: String,
+            required: true
+          },
+
+        ]
+      },
+      {
+        name: "author2",
+        fields: [
+          {
+            name: "name",
+            type: String,
+            required: true
+          },
+        ]
+      }
+    ],
+    form: {
+      name: "",
+      description: "",
+      url: "",
+    }
+
+  },
+  methods: {
+    onSubmit(event) {
+      event.preventDefault()
+      // downloadObjectAsJson(this.form, 'dataset_metadata.json')
+    },
+    onReset(event) {
+      event.preventDefault()
+      // // Reset our form values
+      // this.form.name = '',
+      // this.form.description = '',
+      // this.form.url = '',
+      // this.form.doi = '',
+      // // Trick to reset/clear native browser form validation state
+      // this.show = false
+      // this.$nextTick(() => {
+      //   this.show = true
+      // })
+    },
+    loadSchemas() {
+      
+    }
+  },
+  beforeCreate() {
+    fetch(schema_file)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          console.log(
+            "WARNING: schema file could not be loaded"
+          );
+        }
+      })
+      .then((responseJson) => {
+        obj = responseJson;
+        console.log(obj)
+        this.schema = obj;
+      })
+      .catch((error) => {
+        console.log("Schema file error:");
+        console.log(error);
+      });
+  },
+});

--- a/datalad_catalog/catalog/assets/jsonschema_dataset.json
+++ b/datalad_catalog/catalog/assets/jsonschema_dataset.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://datalad.org/catalog.dataset.schema.json",
+  "title": "dataset",
+  "description": "A dataset in a DataLad Catalog",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "The type of node",
+      "type": "string",
+      "pattern": "dataset"
+    },
+    "dataset_id": {
+      "description": "The dataset ID",
+      "type": "string"
+    },
+    "dataset_version": {
+      "description": "The dataset VERSION",
+      "type": "string"
+    },
+    "name":  {
+      "description": "The long name of the dataset",
+      "type": "string"
+    },
+    "short_name":  {
+      "description": "The short name of the dataset",
+      "type": "string"
+    },
+    "description": {
+      "description": "A 1-2 paragraph description of the dataset",
+      "type": ["array", "string"]
+    },
+    "doi": {
+      "description": "The dataset's digital object identifier",
+      "type": "string"
+    },
+    "url": {
+      "description": "The location of the datalad dataset's annex",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "license": {
+      "description": "The license under which the dataset is made available",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The license name",
+          "type": "string"
+        },
+        "url": {
+          "description": "A URL where a description of the license can be viewed",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "dependentSchemas": {
+        "name": {
+          "required": ["name"]
+        },
+        "url": {
+          "required": ["name"]
+        }
+      }
+    },
+    "authors": { "$ref": "https://datalad.org/catalog.authors.schema.json"},
+    "keywords": {
+      "description": "Tags or keywords describing the dataset",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "funding": {
+      "description": "Sources of funding for the dataset",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Name of the funding source, such as a funder or grant scheme",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "Identifier of the fund, such as a grant number",
+            "type": "string"
+          },
+          "description": {
+            "description": "Free form description of grant or funding",
+            "type": "string"
+          }
+        },
+        "required": []
+      },
+      "uniqueItems": true
+    },
+    "publications": {
+      "description": "Publications related to the dataset",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Type of publication, such as a scholarly article, book, blog post",
+            "type": "string"
+          },
+          "title": {
+            "description": "Title of the publication",
+            "type": "string"
+          },
+          "doi": {
+            "description": "The publication's digital object identifier",
+            "type": "string"
+          },
+          "datePublished": {
+            "description": "The publication date year",
+            "type": ["number", "string"]
+          },
+          "publicationOutlet": {
+            "description": "The publication outlet / venue, such as the journal, publisher name, or news outlet",
+            "type": "string"
+          },
+          "authors": { "$ref": "https://datalad.org/catalog.authors.schema.json"}
+        },
+        "required": ["title", "doi", "authors"]
+      },
+      "uniqueItems": true
+    },
+    "subdatasets": {
+      "description": "Subdatasets of the current dataset",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dataset_id": {
+            "description": "The subdataset ID",
+            "type": "string"
+          },
+          "dataset_version": {
+            "description": "The subdataset VERSION",
+            "type": "string"
+          },
+          "dataset_path": {
+            "description": "The subdataset PATH relative to its parent",
+            "type": "string"
+          }
+        },
+        "required": ["dataset_id", "dataset_version", "dataset_path"]
+      },
+      "uniqueItems": true
+    },
+    "extractors_used": {"$ref": "https://datalad.org/catalog.extractors.schema.json"},
+    "additional_display": {
+      "description": "Additonal items to display in tabs on dataset page",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Name of the section that will appear as the tab name",
+            "type": "string"
+          },
+          "content": {
+            "description": "The content that will appear in the tab when opened, specified as key-value pairs",
+            "type": "object"
+          },
+          "icon": {
+            "description": "An icon from the Font Awesome Free collection (v6.1.1), e.g. 'fas fa-database', that will be displayed in the tab heading",
+            "type": "string"
+          }
+        },
+        "required": ["name", "content"]
+      },
+      "uniqueItems": true
+    },
+    "top_display": {
+      "description": "Additonal items to display at the top of the dataset page (along with keywords, description, etc)",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Name of the item that will appear as part of the top display",
+            "type": "string"
+          },
+          "value": {
+            "description": "Value of the item that will appear as part of the top display",
+            "type": ["number", "string"]
+          }
+        },
+        "required": ["name", "value"]
+      },
+      "uniqueItems": true,
+      "maxItems": 5
+    }
+  },
+  "required": [ "type", "dataset_id", "dataset_version", "name"]
+}
+

--- a/datalad_catalog/catalog/assets/style.css
+++ b/datalad_catalog/catalog/assets/style.css
@@ -94,6 +94,21 @@ body {
 .lfont {
   font-size: large;
 }
+.mfont {
+  font-size: medium;
+}
+.sfont {
+  font-size: small;
+}
+.smfont {
+  font-size: smaller;
+}
+.xsfont {
+  font-size: x-small;
+}
+.xxsfont {
+  font-size: xx-small;
+}
 
 body a {
   color: var(--link-color);
@@ -155,4 +170,51 @@ li[class="item"]:last-child {
   max-height: 360px;
   box-shadow: rgba(50, 50, 93, 0.25) 0 6px 12px -2px, rgba(0, 0, 0, 0.3) 0 3px 7px -3px;
   margin: 2em 0;
+}
+
+.type-indicator {
+  font-family: Menlo, Consolas, monospace;
+  color: #ffffff;
+  border-radius: 5px;
+  padding: 1px;
+  vertical-align: middle;
+}
+
+.type-indicator-required {
+  font-family: Menlo, Consolas, monospace;
+  color: red;
+}
+.type-indicator-optional {
+  font-family: Menlo, Consolas, monospace;
+  color: gray;
+}
+
+.item-line {
+  position: relative;
+  z-index: 0;
+}
+
+.item-line::before {
+  /* we want to draw a line, so no content needed */
+  content: '';
+
+  /* this sets the position and size of the pseudo-element */
+  position: absolute;
+  top: 50%;
+  right: 0.1em;
+  width: 0.5em;
+  height: 1px;
+  background-color: #adb5bd;
+  /* draw behind child elements */
+  z-index: -1;
+}
+
+.validation-text {
+  font-family: Menlo, Consolas, monospace;
+  color: #75787b;
+  border-radius: 4px;
+  border: 1px solid #75787b;
+  padding: 1px;
+  padding-left: 2px;
+  padding-right: 2px;
 }

--- a/datalad_catalog/catalog/display_schema.html
+++ b/datalad_catalog/catalog/display_schema.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+
+    <!-- Required Stylesheets -->
+    <link rel="stylesheet" type="text/css" href="assets/style.css"/>
+    <link rel="stylesheet" type="text/css" href="assets/fontawesome.min.css"/>
+    <link rel="stylesheet" type="text/css" href="assets/brands.min.css"/>
+    <link type="text/css" rel="stylesheet" href="assets/bootstrap.5.1.3.min.css"/>
+    <link type="text/css" rel="stylesheet" href="assets/bootstrap-vue.2.21.2.min.css"/>
+
+    <!-- Required scripts -->
+    <script src="https://unpkg.com/vue@2.6.14/dist/vue.js"></script>
+    <!-- <script src="assets/vue.2.6.14.min.js"></script> -->
+    <script src="assets/bootstrap-vue.2.21.2.min.js"></script>
+
+    <!-- Vue component templates -->
+    <script type="text/x-template" id="schema-item">
+        <b-card no-body class="border-0">
+          <b-card-body class="pb-0">
+            <!-- ITEM TITLE -->
+            <b-card-title>
+              <small>
+                <span class="item-line"></span>
+                <span v-if="'title' in item">
+                  <u>{{item.title}}</u>
+                </span>
+                <span v-else>
+                  <u>{{name}}</u>
+                </span>
+              </small>
+              <small>
+                <span v-if="'type' in item">
+                  <span v-if="Array.isArray(item.type)">
+                    <span v-for="tp in item.type">
+                      <span :style="'background-color:'+type_colors[tp]+';'" class="type-indicator mfont" :id="name+'-'+tp" v-b-tooltip.hover.righttop="'type: '+tp">{{type_icons[tp]}}</span>&nbsp;
+                    </span>
+                  </span>
+                  <span v-else :style="'background-color:'+type_colors[item.type]+';'" class="type-indicator mfont" :id="name+'-'+item.type" v-b-tooltip.hover.righttop="'type: '+item.type">{{type_icons[item.type]}}</span>
+                </span>
+                <span v-if="'$ref' in item" :style="'background-color:'+type_colors['$ref']+';'" class="type-indicator mfont" :id="name+'-ref'" v-b-tooltip.hover.righttop="'type: $ref'">{{type_icons['$ref']}}</span>
+                <span v-if="requireditems && requireditems.indexOf(name) >= 0" class="type-indicator-required mfont">
+                  required</span>
+                <span v-else class="type-indicator-optional mfont">
+                  [optional]</span>
+              </small>
+            </b-card-title>
+            <!-- ITEM ANNOTATIONS -->
+            <b-card-text class="mb-1 sfont">
+              <b-container style="padding-left: 0;">
+                <b-row>
+                  <b-col cols="6">
+                    <b-container style="padding-left: 0;">
+                      <span v-for="kw in defaults.schema_keywords.concat(defaults.instance_keywords).concat(defaults.schema_annotations).concat(defaults.additional_keywords)">
+                        <b-row  v-if="kw in item">
+                          <b-col cols="3"><strong>{{kw}}:</strong></b-col>
+                          <b-col>{{item[kw]}}</b-col>
+                        </b-row>
+                      </span>
+                      <span v-if="(Array.isArray(item.type) ? item.type : [item.type]).indexOf('array') >= 0">
+                        <b-row>
+                          <b-col cols="3"><strong>Array Item Type:</strong></b-col>
+                          <b-col>{{item[kw]}}</b-col>
+                        </b-row>
+                      </span>
+                    </b-container>
+                  </b-col>
+                  <b-col>
+                    <span v-if="'type' in item && hasvalidations">
+                      <em>Validations:</em>
+                      <span v-for="tp in (Array.isArray(item.type) ? item.type : [item.type])">
+                        <span v-for="(kw, index) in Object.keys(defaults.validation_keywords[tp])">
+                          <span v-if="kw in item" class="validation-text">{{kw}}: {{item[kw]}}</span>
+                        </span>
+                      </span>
+                    </span>
+                  </b-col>
+                </b-row>
+              </b-container>
+            </b-card-text>
+            <!-- OBJECT ITEM: PROPERTIES -->
+            <b-card-text>
+              <span v-if="(Array.isArray(item.type) ? item.type : [item.type]).indexOf('object') >= 0">
+                <b-button size="sm" class="pt-0 pb-0" variant="outline-secondary" v-b-toggle="name+'-props'">Properties</b-button>
+                <b-collapse :id="name+'-props'">
+                  <b-card no-body border-variant="default">
+                    <schema-item v-for="key in Object.keys(item.properties)" :name="key" :item="item.properties[key]" :defaults="defaults" :requireditems="item.required"></schema-item>
+                  </b-card>
+                </b-collapse>
+              </span>
+              <!-- ARRAY ITEM: DETAILS -->
+              <span v-if="(Array.isArray(item.type) ? item.type : [item.type]).indexOf('array') >= 0">
+                <span v-if="item.items.type == 'object'">
+                  <b-button size="sm" class="pt-0 pb-0" variant="outline-secondary" v-b-toggle="name+'items-props'">Array Item Properties</b-button>
+                  <b-collapse :id="name+'items-props'">
+                    <b-card no-body border-variant="default">
+                      <schema-item v-for="key in Object.keys(item.items.properties)" :name="key" :item="item.items.properties[key]" :defaults="defaults" :requireditems="item.items.required"></schema-item>
+                    </b-card>
+                  </b-collapse>
+                </span>
+              </span>
+            </b-card-text>
+          </b-card-body>
+        </b-card>
+    </script>
+  </head>
+
+  <!-- ### -->
+  <!-- ### -->
+  <!-- ### -->
+  <!-- Our application root element -->
+  <body>
+    <b-container id="vue_app">
+      <b-card no-body border-variant="dark">
+        <b-card-body>
+          <b-card-title>
+            <u>Schema: {{schema.title}}</u>
+          </b-card-title>
+          <b-card-text class="mb-1">
+            <b-container style="padding-left: 0;">
+              <b-row>
+                <b-col cols="6">
+                  <b-container style="padding-left: 0;">
+                    <span v-for="kw in defaults.schema_keywords.concat(defaults.instance_keywords).concat(defaults.schema_annotations).concat(defaults.additional_keywords)">
+                      <b-row  v-if="kw in schema">
+                        <b-col cols="3"><strong>{{kw}}:</strong></b-col>
+                        <b-col>{{schema[kw]}}</b-col>
+                      </b-row>
+                    </span>
+                  </b-container>
+                </b-col>
+                <b-col>
+                </b-col>
+              </b-row>
+            </b-container>
+          </b-card-text>
+          <b-card-text>
+            <span v-if="schema.type == 'object'">
+              <b-button size="sm" class="pt-0 pb-0" variant="outline-secondary" v-b-toggle="'schema-props'">Properties</b-button>
+              <b-collapse id="schema-props">
+                <b-card no-body border-variant="default">
+                  <schema-item v-for="key in Object.keys(schema.properties)" :name="key" :item="schema.properties[key]" :defaults="defaults" :requireditems="schema.required"></schema-item>
+                </b-card>
+              </b-collapse>
+            </span>
+          </b-card-text>
+        </b-card-body>
+      </b-card>
+    </b-container>
+    <br><br><br><br>
+    <!-- Start running your app -->
+    <script src="assets/display_schema.js"></script>
+  </body>
+</html>

--- a/datalad_catalog/catalog/display_schema.html
+++ b/datalad_catalog/catalog/display_schema.html
@@ -64,7 +64,7 @@
                       <span v-if="(Array.isArray(item.type) ? item.type : [item.type]).indexOf('array') >= 0">
                         <b-row>
                           <b-col cols="3"><strong>Array Item Type:</strong></b-col>
-                          <b-col>{{item[kw]}}</b-col>
+                          <b-col>{{item.items.type}}</b-col>
                         </b-row>
                       </span>
                     </b-container>


### PR DESCRIPTION
This PR:
- adds initial code to auto-render a human readable version of a json-schema definition, in this case for the catalog's `dataset` schema.
- addresses the basics of https://github.com/datalad/datalad-catalog/issues/74 for `dataset` schema in particular
- puts the first part of the code in place in order to auto-generate a form from json-schema, towards addressing https://github.com/datalad/datalad-catalog/issues/204 (see here in relation to gooey: https://github.com/datalad/datalad-gooey/issues/329)
- compatible with [jsonschema draft 2020](https://json-schema.org/draft/2020-12/release-notes.html) (mostly...)

Remaining challenges:
- the current setup ignores schema references. References would need to be resolved and aggregated into the top-level schema in order to be rendered by the current code.
- the current example is arbitrarily done for the `dataset` schema. Other catalog schemas also need to be rendered for documentation purposes

TODO based on this work:
- figure out the steps to resolve referenced schemas
- allows users to upload schemas to be rendered
- address https://github.com/datalad/datalad-catalog/issues/204