### PR TITLE
DOC: catalog schema rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This demo site is hosted via GitHub Pages and it builds from the `gh-pages` bran
 
 ## 2. How it works
 
-DataLad Catalog can receive commands to `create` a new catalog, `add` and `remove` metadata entries to/from an existing catalog, `serve` an existing catalog locally, and more. Metadata can be provided to DataLad Catalog from any number of arbitrary metadata sources, as an aggregated set or as individual metadata items. DataLad Catalog has a dedicated schema (using the [JSON Schema](https://json-schema.org/) vocabulary) against which incoming metadata items are validated. This schema allows for standard metadata fields as one would expect for datasets of any kind (such as `name`, `doi`, `url`, `description`, `license`, `authors`, and more), as well as fields that support identification, versioning, dataset context and linkage, and file tree specification.
+DataLad Catalog can receive commands to `create` a new catalog, `add` and `remove` metadata entries to/from an existing catalog, `serve` an existing catalog locally, and more. Metadata can be provided to DataLad Catalog from any number of arbitrary metadata sources, as an aggregated set or as individual metadata items. DataLad Catalog has a dedicated [schema](https://datalad.github.io/datalad-catalog/display_schema) (using the [JSON Schema](https://json-schema.org/) vocabulary) against which incoming metadata items are validated. This schema allows for standard metadata fields as one would expect for datasets of any kind (such as `name`, `doi`, `url`, `description`, `license`, `authors`, and more), as well as fields that support identification, versioning, dataset context and linkage, and file tree specification.
 
 The process of generating a catalog, after metadata entry validation, involves:
 1. aggregation of the provided metadata into the catalog filetree, and
@@ -99,8 +99,8 @@ The overall catalog generation process actually starts several steps before the 
 1. curating data into datasets (a group of files in an hierarchical tree)
 2. adding metadata to datasets and files (the process for this and the resulting metadata formats and content vary widely depending on domain, file types, data availability, and more)
 3. extracting the metadata using an automated tool to output metadata items into a standardized and queryable set
-4. in the current context: translating the metadata into the catalog schema
-5. in the current context: using `datalad-catalog` to generate a catalog from the schema-conforming metadata
+4. in the current context: translating the metadata into the [catalog schema](https://datalad.github.io/datalad-catalog/display_schema)
+5. in the current context: using `datalad-catalog` to generate a catalog from the [schema-conforming metadata](https://datalad.github.io/datalad-catalog/display_schema)
 
 The first four steps in this list can follow any arbitrarily specified procedures and can use any arbitrarily specified tools to get the job done. If these steps are completed, correctly formatted data can be input, together with some configuration details, to `datalad-catalog`. This tool then provides several basic commands for catalog generation and customization. *For example:*
 
@@ -141,7 +141,7 @@ The DataLad ecosystem provides a complete set of free and open source tools that
 
 DataLad itself can be used for decentralised management of data as lightweight, portable and extensible representations. DataLad MetaLad can extract structured high- and low-level metadata and associate it with these datasets or with individual files. And at the end of the workflow, DataLad Catalog can turn the structured metadata into a user-friendly data browser.
 
-Importantly, DataLad Catalog can operate independently as well. Since it provides its own schema in a standard vocabulary, any metadata that conforms to this schema can be submitted to the tool in order to generate a catalog. Metadata items do not necessarily have to be derived from DataLad datasets, and the metadata extraction does not have to be conducted via DataLad MetaLad.
+Importantly, DataLad Catalog can operate independently as well. Since it provides its own [schema](https://datalad.github.io/datalad-catalog/display_schema) in a standard vocabulary, any metadata that conforms to this schema can be submitted to the tool in order to generate a catalog. Metadata items do not necessarily have to be derived from DataLad datasets, and the metadata extraction does not have to be conducted via DataLad MetaLad.
 
 Even so, the provided set of tools can be particularly powerful when used together in a distributed (meta)data management pipeline.
 

--- a/docs/source/catalog_schema.rst
+++ b/docs/source/catalog_schema.rst
@@ -1,0 +1,28 @@
+Catalog Schema
+**************
+
+Metadata submitted to DataLad Catalog has to conform to its own `schema`_, which
+uses the vocabulary defined by `JSON Schema`_ (specifically `draft 2020-12`_).
+
+Source files defining the catalog's schema can be found here:
+
+- `catalog`_
+- `dataset`_
+- `file`_
+- `authors`_
+- `extractors`_
+
+
+A rendering of the schema can be accessed at:
+https://datalad.github.io/datalad-catalog/display_schema.html
+
+
+
+.. _draft 2020-12: https://json-schema.org/specification.html
+.. _JSON Schema: https://json-schema.org/
+.. _schema: https://datalad.github.io/datalad-catalog/display_schema
+.. _catalog: https://raw.githubusercontent.com/datalad/datalad-catalog/main/datalad_catalog/schema/jsonschema_catalog.json
+.. _dataset: https://raw.githubusercontent.com/datalad/datalad-catalog/main/datalad_catalog/schema/jsonschema_dataset.json
+.. _file: https://raw.githubusercontent.com/datalad/datalad-catalog/main/datalad_catalog/schema/jsonschema_file.json
+.. _authors: https://raw.githubusercontent.com/datalad/datalad-catalog/main/datalad_catalog/schema/jsonschema_authors.json
+.. _extractors: https://raw.githubusercontent.com/datalad/datalad-catalog/main/datalad_catalog/schema/jsonschema_extractors.json

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,6 +42,7 @@ Index
    usage
    pipeline_description
    metadata_formats
+   catalog_schema
    examples
    design
    contributing

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -28,16 +28,28 @@ With `miniconda`_:
     conda activate my_catalog_env
 
 
-Step 2 - Clone the repo and install the package
-===============================================
+Step 2 - Install via `PyPI`_
+============================
+
+.. code-block:: bash
+
+    pip install datalad-catalog
+
+
+Congratulations! You have now installed DataLad Catalog!
+
+
+Optional - Clone the repo and install the package
+=================================================
+
+If you want to access the latest, unreleased version of the software or 
+contribute to the code, access the repository via `GitHub`_:
 
 .. code-block:: bash
 
     git clone https://github.com/datalad/datalad-catalog.git
     cd datalad-catalog
     pip install -e .
-
-Congratulations! You have now installed DataLad Catalog!
 
 
 Dependencies
@@ -60,8 +72,10 @@ metadata originating only from ``datalad-metalad``'s extractors, this tool has
 advanced metadata handling capabilities that will integrate seamlessly with
 DataLad datasets and the catalog generation process.
 
-.. _venv: https://github.com/pypa/virtualenv
-.. _miniconda: https://docs.conda.io/en/latest/miniconda.html
 .. _datalad: https://github.com/datalad/datalad
+.. _GitHub: https://github.com/datalad/datalad-catalog
 .. _datalad-metalad: https://github.com/datalad/datalad-metalad
 .. _DataLad Handbook: https://handbook.datalad.org/en/latest/intro/installation.html
+.. _miniconda: https://docs.conda.io/en/latest/miniconda.html
+.. _PyPI: https://pypi.org/project/datalad-catalog/
+.. _venv: https://github.com/pypa/virtualenv

--- a/docs/source/metadata_formats.rst
+++ b/docs/source/metadata_formats.rst
@@ -31,8 +31,8 @@ standard files (such as `Digital Imaging and Communications in Medicine`_, i.e. 
 also supply embedded or sidecar metadata.
 
 .. note:: In order to create a user-friendly catalog, DataLad Catalog should receive 
-    structured metadata as input. This means that structured metadata first has to be
-    extracted from your DataLad dataset.
+    structured metadata adhering to a specified :doc:`catalog_schema` as input. This means
+    that structured metadata first has to be extracted from your DataLad dataset.
 
 
 Metadata Extractors
@@ -70,6 +70,3 @@ first having to add specific metadata content to the dataset) MetaLad has the bu
 .. _Extensible Metadata Platform: https://en.wikipedia.org/wiki/Extensible_Metadata_Platform
 .. _Frictionless Data Package: https://specs.frictionlessdata.io/data-package/
 .. _Digital Imaging and Communications in Medicine: https://www.dicomstandard.org/
-
-
-

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -16,7 +16,8 @@ data catalog.
 
 |
 
-It is an extension to, and dependent on, `Datalad`_ and `Datalad Metalad`_:
+It is an extension to, and dependent on, `Datalad`_, and is interoperable with 
+`Datalad Metalad`_:
 
 - **DataLad** is a distributed data management system that keeps track of
   your data, creates structure, ensures reproducibility, supports collaboration,
@@ -84,12 +85,12 @@ DataLad Catalog can receive commands to ``create`` a new catalog, ``add`` and
 ``remove`` metadata entries to/from an existing catalog, ``serve`` an existing
 catalog locally, and more. Metadata can be provided to DataLad Catalog from any
 number of arbitrary metadata sources, as an aggregated set or as individual
-items/objects. DataLad Catalog has a dedicated schema (using the `JSON Schema`_
-vocabulary) against which incoming metadata items are validated. This schema
-allows for standard metadata fields as one would expect for datasets of any kind
-(such as ``name``, ``doi``, ``url``, ``description``, ``license``, ``authors``,
-and more), as well as fields that support identification, versioning, dataset
-context and linkage, and file tree specification.
+items/objects. DataLad Catalog has a dedicated :doc:`catalog_schema` (using the
+`JSON Schema`_ vocabulary) against which incoming metadata items are validated.
+This schema allows for standard metadata fields as one would expect for datasets
+of any kind (such as ``name``, ``doi``, ``url``, ``description``, ``license``,
+``authors``, and more), as well as fields that support identification, versioning,
+dataset context and linkage, and file tree specification.
 
 The process of generating a catalog, after metadata entry validation, involves:
 
@@ -111,7 +112,10 @@ For an example of the result, visit our `demo catalog`_.
 
 .. _DataLad: https://github.com/datalad/datalad
 .. _DataLad Metalad: https://github.com/datalad/datalad-metalad
+.. _demo catalog: https://datalad.github.io/datalad-catalog/
 .. _JSON Schema: https://json-schema.org/
 .. _Vue.js: https://vuejs.org/
-.. _demo catalog: https://datalad.github.io/datalad-catalog/
+
+
+
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -45,7 +45,8 @@ Add metadata
 To add metadata to an existing catalog, run ``datalad catalog add``, specifying
 the location of the metadata to add. The DataLad Catalog accepts metadata in the
 form of json lines, i.e. a text file (typically ``.json``, ``.jsonl``, or
-``.txt``) where each line is a single, correctly formatted JSON object.
+``.txt``) where each line is a single, correctly formatted JSON object. The correct
+format for the added metadata is specified by the :doc:`catalog_schema`.
 
 .. code-block:: bash
 
@@ -57,7 +58,7 @@ The ``metadata`` directory is now populated.
 Metadata validation
 -------------------
 To check if metadata is valid before adding it to a catalog, ``datalad catalog
-validate`` can be run to check if the metadata conforms to the Catalog schema.
+validate`` can be run to check if the metadata conforms to the :doc:`catalog_schema`.
 
 .. code-block:: bash
 


### PR DESCRIPTION
This PR:
- updates docs and readme to include references to the rendered [catalog schema](https://datalad.github.io/datalad-catalog/display_schema.html)
- closes #74 