### PR TITLE
NF: automatic form generation from jsonschema

### DIFF
--- a/datalad_catalog/catalog/assets/display_schema.js
+++ b/datalad_catalog/catalog/assets/display_schema.js
@@ -8,9 +8,30 @@ const file_schema_file = "./assets/jsonschema_file.json";
 const extractors_schema_file = "./assets/jsonschema_extractors.json";
 const catalog_schema_file = "./assets/jsonschema_catalog.json";
 
+const TYPES =  [
+  "string",
+  "number",
+  "integer",
+  "object",
+  "array",
+  "boolean",
+  "null",
+]
+
+const ARRAY = 'array'
+const ID = '$id'
+const ITEMS = 'items'
+const NULL = null
+const OBJECT = 'object'
+const PROPERTIES = 'properties'
+const REF = '$ref'
+const REQUIRED = 'required'
+const SCHEMA = '$schema'
+const TYPE = 'type'
+
 
 schema_files = {
-  "jsonschema_catalog": catalog_schema_file,
+  // "jsonschema_catalog": catalog_schema_file,
   "jsonschema_dataset": dataset_schema_file,
   "jsonschema_file": file_schema_file,
   "jsonschema_authors": authors_schema_file,
@@ -21,8 +42,7 @@ schema_keywords = ["$schema", "$id"]
 instance_keywords = ["type"]
 schema_annotations = ["title", "description", "default", "examples", "readOnly", "writeOnly", "deprecated"]
 additional_schema_keywords = ["$ref", "$defs"]
-validation_keywords = ["properties", "additionalProperties", "required", "items", "multipleOf", "maximum", "minimum", "exclusiveMaximum", "exclusiveMinimum", "minItems", "maxItems", "uniqueItems"]
-
+// validation_keywords = ["properties", "additionalProperties", "required", "items", "multipleOf", "maximum", "minimum", "exclusiveMaximum", "exclusiveMinimum", "minItems", "maxItems", "uniqueItems"]
 validation_keywords = {
   any: {
     // type
@@ -66,33 +86,13 @@ validation_keywords = {
   },
 }
 
-// top_level_fields = {
-//   "$schema": "string",
-//   "$id": "string",
-//   "$comment": "string",
-//   "$ref": "string",
-//   "type": ["string", "array"],
-//   "title": "string",
-//   "description": "string",
-//   "default": "any",
-//   "examples": "array",
-//   "readOnly": "boolean",
-//   "writeOnly": "boolean",
-//   "deprecated": "boolean",
-//   "enum": "array",
-//   "const": "any",
-//   "required": "array"
-// }
-
-const types =  [
-  "string",
-  "number",
-  "integer",
-  "object",
-  "array",
-  "boolean",
-  "null",
-]
+defaults = {
+  schema_keywords: schema_keywords,
+  instance_keywords: instance_keywords,
+  schema_annotations: schema_annotations,
+  additional_keywords: additional_schema_keywords,
+  validation_keywords: validation_keywords,
+}
 
 format = [
   "date-time",
@@ -116,14 +116,6 @@ format = [
   "regex",
 ]
 
-defaults = {
-  schema_keywords: schema_keywords,
-  instance_keywords: instance_keywords,
-  schema_annotations: schema_annotations,
-  additional_keywords: additional_schema_keywords,
-  validation_keywords: validation_keywords,
-}
-
 const INPUT_TYPES = [
   'text',
   'password',
@@ -141,6 +133,24 @@ const INPUT_TYPES = [
   'range',
   'color'
 ]
+
+const TYPE_MAP = {
+  "string": "text",
+  "number": "number",
+  "integer": "number",
+  "object": null,
+  "array": null,
+  "boolean": null,
+  "null": null,
+}
+
+const FORMAT_MAP = {
+  "date-time": "datetime",
+  "time": "time",
+  "date": "date",
+  "duration": "time",
+  "email": "email",
+}
 
 type_icons = {
   "string": "““",
@@ -164,33 +174,17 @@ type_colors = {
   "$ref": "#17a2b8" //  cyan
 }
 
-// required: red
-// optional: orange
-
-// $blue: #007bff !default;
-// $indigo: #6610f2 !default;
-// $purple: #6f42c1 !default;
-// $pink: #e83e8c !default;
-// $red: #dc3545 !default;
-// $orange: #fd7e14 !default;
-// $yellow: #ffc107 !default;
-// $green: #28a745 !default;
-// $teal: #20c997 !default;
-// $cyan: #17a2b8 !default;
 
 
 
-Vue.component("t-custom-input", {
-  template: "#custom-input-template",
-  props: [
-    'value'
-  ],
-})
+// COMPONENTS
 
+// SCHEMA-ITEM
 Vue.component("schema-item", {
   template: "#schema-item",
   props: [
     'name',
+    'parent_name',
     'item',
     'defaults',
     'requireditems',
@@ -227,13 +221,11 @@ Vue.component("schema-item", {
     }
   },
   methods: {
-    selectRefSchema(ref_id) {
-
-    }
-  }
+  },
 })
 
 
+// T-INPUT
 Vue.component("t-input", {
   template: "#input-template",
   data: function () {
@@ -246,7 +238,7 @@ Vue.component("t-input", {
   },
   props: [
     'obj',
-    'defs'
+    'i',
   ],
   methods: {
     removeItemModal(idx) {
@@ -270,19 +262,22 @@ Vue.component("t-input", {
           // An error occurred
         })
     },
-    addItemModal(idx, def) {
+    addItemModal(idx) {
       this.edited_item = {}
       this.edit_existing = false
-      if (Number.isFinite(idx)) {
-        this.edit_index = idx
-        this.edit_existing = true
-        this.edited_item = JSON.parse(JSON.stringify(this.obj.value[idx]))
-      }
-      else {
-        key_list = def.fields.map(f => 
-          this.edited_item[f.name] = "")
-      }
+      // if (Number.isFinite(idx)) {
+      //   this.edit_index = idx
+      //   this.edit_existing = true
+      //   this.edited_item = JSON.parse(JSON.stringify(this.obj.value[idx]))
+      // }
+      // else {
+      //   key_list = def.fields.map(f => 
+      //     this.edited_item[f.name] = "")
+      // }
       this.$refs['additem'].show()
+    },
+    closeItemModal() {
+      this.$refs['additem'].hide()
     },
     saveItem() {
       if (this.edit_existing) {
@@ -299,15 +294,119 @@ Vue.component("t-input", {
 
   },
   computed: {
-    state() {
-      return this.obj.value.length == 4
+    array_fields() {
+      // Return fields belonging to a single item in an array
+      // Fields could be standalone, or could derive from an object
+      if (this.obj.input_type == ARRAY) {
+        if (this.obj.children[0]) {
+          if (this.obj.children[0].input_type == OBJECT) {
+            fields = this.obj.children[0].children.map(f => f.form_field)
+          } else {
+            fields = [this.obj.children[0].form_field]
+          }
+        } else {
+          fields = [this.obj.form_field]
+        }
+        fields.forEach(function(el, idx, arr) {
+          arr[idx] = {key: el};
+          arr[idx].thStyle = { fontWeight: 'normal', fontStyle: 'italic'}
+        });
+
+        aa = fields.concat([{ key: 'opts', label: 'Options', thStyle: { fontWeight: 'normal', fontStyle: 'italic'}}])
+        console.log(aa)
+        return aa
+      }
+      return null
     },
+
+    input_label() {
+      return makeReadable(this.obj.label)
+    }
+
+    // state() {
+    //   return this.obj.value.length == 4
+    // },
     // invalidFeedback() {
     //   if (this.obj.value.length > 0) {
     //     return 'Enter at least 4 characters.'
     //   }
     //   return 'Please enter something.'
     // }
+  },
+})
+
+
+// SCHEMA-FORM
+Vue.component("schema-form", {
+  template: "#form-template",
+  props: [
+    'title',
+    'form_config',
+    'toplevel',
+  ],
+  data: function () {
+    return {
+    }
+  },
+  computed: {
+    form_data() {
+      var dat = {}
+      var fields = this.form_config.children
+      for (var i=0; i<fields.length; i++) {
+        var f = fields[i]
+        switch (f.input_type) {
+          case 'array':
+            dat[f.form_field] = [];
+            break;
+          case 'object':
+            dat[f.form_field] = {};
+            break;
+          case 'text':
+            dat[f.form_field] = '';
+            break;
+          default:
+            dat[f.form_field] = null;
+        }
+      }
+      return dat
+    }
+  },
+  methods: {
+    onSubmit(event) {
+      event.preventDefault()
+      // downloadObjectAsJson(this.form, 'dataset_metadata.json')
+    },
+    onReset(event) {
+      event.preventDefault()
+      // // Reset our form values
+      // this.form.name = '',
+      // this.form.description = '',
+      // this.form.url = '',
+      // this.form.doi = '',
+      // // Trick to reset/clear native browser form validation state
+      // this.show = false
+      // this.$nextTick(() => {
+      //   this.show = true
+      // })
+    },
+    onCancel(event) {
+      console.log(event)
+      console.log(event.target)
+      console.log(this.$refs)
+      console.log(this.$parent.$refs)
+      console.log(this.$parent.$parent.$refs)
+      console.log(this.$parent.$parent.$parent.$refs)
+      // console.log()
+      // console.log(this.$refs)
+      if (!this.toplevel) {
+        // console.log(this.$refs.forminput[0].$refs.additem)
+        // this.$refs.forminput.length
+        // this.$parent.$parent.hide()
+        
+        // this.$refs['additem'].hide()
+      }
+      // event.preventDefault()
+    },
   },
 })
 
@@ -324,102 +423,14 @@ var form_app = new Vue({
     schemas_json: {},
     schema: {},
     schemas_ready: false,
+    schema_selected: false,
+    schema_name: "",
     defaults: defaults,
     searchText: "",
     headingText: "kaas",
     inputTypes: INPUT_TYPES,
-    inputData: [
-      {
-        description: "The name of your dataset",
-        input_id: "input-2",
-        input_group_id: "input-group-2",
-        label: "Name",
-        required: true,
-        form_field: "name",
-        placeholder: "placeholder2",
-        input_type: "text",
-        value: "",
-
-      },
-      {
-        description: "The description of your dataset",
-        input_id: "input-1",
-        input_group_id: "input-group-1",
-        label: "Description",
-        required: true,
-        form_field: "description",
-        placeholder: "placeholder1",
-        input_type: "textarea",
-        value: "",
-      },
-      {
-        description: "The URL of your dataset",
-        input_id: "input-3",
-        input_group_id: "input-group-3",
-        label: "URL",
-        required: false,
-        form_field: "url",
-        placeholder: "placeholder3",
-        input_type: "url",
-        value: "",
-      },
-      {
-        description: "Dataset authors",
-        input_id: "input-4",
-        input_group_id: "input-group-4",
-        label: "Authors",
-        required: false,
-        form_field: "authors",
-        placeholder: "placeholder4",
-        input_type: "array",
-        value: [
-          {
-            name: "Stephan",
-            lastname: "Heunis"
-          },
-          {
-            name: "Stephan2",
-            lastname: "Heunis2"
-          },
-
-        ],
-        item_def: "author"
-      }
-    ],
-    definitions: [
-      {
-        name: "author",
-        fields: [
-          {
-            name: "name",
-            type: String,
-            required: true
-          },
-          {
-            name: "lastname",
-            type: String,
-            required: true
-          },
-
-        ]
-      },
-      {
-        name: "author2",
-        fields: [
-          {
-            name: "name",
-            type: String,
-            required: true
-          },
-        ]
-      }
-    ],
-    form: {
-      name: "",
-      description: "",
-      url: "",
-    }
-
+    show_form: false,
+    form_config: {},
   },
   methods: {
     onSubmit(event) {
@@ -440,8 +451,11 @@ var form_app = new Vue({
       // })
     },
     selectSchema(s) {
+      // this.schema_selected = false;
+      this.schema_name = s;
       this.schema = this.schemas_json[s];
-      console.log(this.schema)
+      this.show_form = false;
+      // this.schema_selected = true;
     },
     selectRefSchema(ref_id) {
       filtered_schemas = Object.values(this.schemas_json).filter(
@@ -454,6 +468,20 @@ var form_app = new Vue({
       if (Array.isArray(filtered_schemas)) {
         this.schema = filtered_schemas[0]
       }
+    },
+    addMetadata(schema) {
+      var resolved_schema = resolveSchemaNew(schema, this.schemas_json);
+      var name =  schema.title
+      this.form_config = parseSchema(name, resolved_schema, null, [])
+      this.show_form = true;
+    },
+    getResolvedSchema(schema) {
+      var resolved_schema = resolveSchemaNew(schema, this.schemas_json);
+      var name =  schema.title
+      var form_config = parseSchema(name, resolved_schema, null, [])
+      downloadObjectAsJson(resolved_schema, 'resolved_schema')
+      downloadObjectAsJson(form_config, 'form_config')
+
     },
     gotoHome() {
       router.push({ name: "home" });
@@ -498,6 +526,7 @@ var form_app = new Vue({
           this.schemas_json[key] = obj;
           if (index == 0) {
             this.schema = obj
+            this.schema_name = key;
           }
         })
         .catch((error) => {
@@ -512,3 +541,232 @@ var form_app = new Vue({
     )
   },
 });
+
+
+function parseSchema(name, schema, input_count = null, required = []) {
+
+  console.log("parseschema called...")
+  // assume schema has already been resolved
+
+  // Schema should be an object
+  // if (!isObject(schema)) {
+  //   console.log("ERROR: schema should be an object")
+  //   return false
+  // }
+  // If schema has no type, cannot add metadata (ignore allOf etc for now... TODO)
+  console.log(schema)
+  if (!(TYPE in schema)) {
+    console.log("ERROR: schema has no 'type' or '$ref' at the top level and cannot be parsed")
+    return false
+  }
+
+  // input count
+  if (!input_count) {
+    input_count = 1;
+  } else {
+    input_count++;
+  }
+
+  // initialise
+  var item = {
+    description: schema.description ? schema.description: "",
+    input_id: "input-" + input_count.toString(), //"input-1"
+    input_group_id: "input-group-" + input_count.toString(), // "input-group-x",
+    label: schema.title ? schema.title: name,
+    required: required.indexOf(name) >= 0 ? true : false,
+    form_field: name, //"description"
+    placeholder: "",  // "placeholder1"
+    input_type: "", // 
+    type: null,
+    value: null,
+    validations: [],
+    children: [],
+  }
+
+  schema_keywords.concat(schema_annotations).forEach(
+    kw => {
+      if (kw in schema) {
+        item[kw] = schema[kw]
+      }
+    }
+  );
+  // Make sure type keyword exists, then parse
+  if (TYPE in schema) {
+    tp = schema[TYPE]
+    // type could be an array or a string -> turn all into array
+    var type_array = Array.isArray(tp) ? tp : [tp]
+    item.type = type_array
+    item.input_type = Array.isArray(tp) ? "" : TYPE_MAP[tp]
+    if (allInArray(type_array, TYPES)) {
+      // lets assume hierarchy for now (array -> object -> others),
+      // need to deal with multiple types per item later: TODO
+      if (type_array.includes(ARRAY)) {
+        item.input_type = "array"
+        item.value = []
+        if (ITEMS in schema ) {
+          input_count++
+          arr_item = parseSchema(name, schema.items, input_count, schema[REQUIRED])
+          item.children.push(arr_item)
+        }
+        // addObjectToArray(arr_item, item.children, 'form_field')
+      }
+      if (type_array.includes(OBJECT) && PROPERTIES in schema) {
+        item.input_type = "object"
+        for (prop in schema[PROPERTIES]) {
+          input_count++
+          prop_item = parseSchema(prop, schema[PROPERTIES][prop], input_count, schema[REQUIRED])
+          item.children.push(prop_item)
+          // addObjectToArray(prop_item, item.children, 'form_field')
+        }
+      }
+      
+    } else {
+      console.log("ERROR: type '" + type_array + "' not supported by jsonschema draft 2020-12" )
+    }
+  } else {
+    // TODO: handle cases such as allof and whatever else!!!
+    console.log("ERROR: keyword 'type' not in schema")
+    return false
+  }
+
+  return item
+}
+
+
+
+function resolveSchemaNew(schema, available_schemas) {
+
+  // prompt(JSON.stringify(schema, null, 2))
+
+  var resolved_schema = structuredClone(schema)
+  for (key in resolved_schema) {
+    // console.log(key)
+    if (key == REF) {
+      resolved_schema = resolveSchemaItem(key, structuredClone(resolved_schema[key]), available_schemas)
+    } else if (key == PROPERTIES || (key == ITEMS && resolved_schema[ITEMS].hasOwnProperty(PROPERTIES))) {
+      resolved_schema[key] = resolveSchemaItem(key, structuredClone(resolved_schema[key]), available_schemas)
+    } else {
+      // console.log('doing nothing')
+      continue
+    }
+  }
+  return resolved_schema
+}
+
+function resolveSchemaItem(key, item, available_schemas) {
+  // console.log()
+  // console.log(item)
+
+  if (key == REF) {
+    // console.log('goint into ref: ' + item)
+    ref_schema = findRefSchema(item, available_schemas)
+    if (ref_schema) {
+      item = resolveSchemaNew(structuredClone(ref_schema), available_schemas)
+    }
+  }
+  
+  if (key == PROPERTIES) {
+    // console.log("going into properties:")
+    // console.log(item)
+    for (prop in item) {
+      // console.log("property: " + prop)
+      // console.log(item) 
+      item[prop] = resolveSchemaNew(structuredClone(item[prop]), available_schemas)
+    }
+  }
+  if (key == ITEMS ) {
+    for (prop in item[PROPERTIES]) {
+      item[PROPERTIES][prop] = resolveSchemaNew(structuredClone(item[PROPERTIES][prop]), available_schemas)
+    }
+  } else {
+    // console.log('doing nothing')
+  }
+  return item
+}
+
+
+function isObject(x) {
+  // Returns true if the argument is an object
+  // console.log('x: ' + x + ';  x !== null: ' + (x !== null).toString() )
+  // console.log('typeof x: ' + (typeof x).toString() + 'typeof x === object: ' + (typeof x === 'object').toString())
+  // console.log('!isArray(x): ' + !Array.isArray(x))
+  
+  if ( typeof x === 'object' && !Array.isArray(x) && x !== null ) {
+    return true
+  } else {
+    return false
+  }
+}
+
+
+function findRefSchema(ref_id, available_schemas) {
+  // Find a schema by id in the locally available schemas
+  filtered_schemas = Object.values(available_schemas).filter(
+    (obj) => {
+      if ('$id' in obj) {
+        return obj['$id'].toLowerCase().indexOf(ref_id.toLowerCase()) >= 0
+      }
+    }
+  );
+  if (Array.isArray(filtered_schemas)) {
+    return filtered_schemas[0]
+  } else {
+    return false
+  }
+}
+
+
+function objectInArray(prop, val, arr) {
+  console.log('prop')
+  console.log(prop)
+  console.log('val')
+  console.log(val)
+  console.log('arr')
+  console.log(arr)
+  // Checks if an object already exists in an array
+  var result = arr.find(obj => {
+    return obj[prop] === val
+  })
+
+  if (typeof result !== 'undefined') {
+    return result;
+  } else {
+    return null
+  }
+}
+
+function addObjectToArray(obj, arr, prop_to_check) {
+  // Adds an object to an array unless the object already exists in the array
+  if (objectInArray(prop_to_check, obj[prop_to_check], arr)) {
+    return arr
+  } else {
+    return arr.push(obj)
+  }
+}
+
+function allInArray(small_array, big_array) {
+  // return true if all elements of small_array are in big_array
+  return small_array.every(el => big_array.includes(el))
+}
+
+
+function downloadObjectAsJson(obj, filename){
+  var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(obj));
+  var downloadAnchorNode = document.createElement('a');
+  downloadAnchorNode.setAttribute("href",     dataStr);
+  downloadAnchorNode.setAttribute("download", filename + ".json");
+  document.body.appendChild(downloadAnchorNode);
+  downloadAnchorNode.click();
+  downloadAnchorNode.remove();
+}
+
+
+function makeReadable(input) {
+  // capitalize first letter
+  var output = input.charAt(0).toUpperCase() + input.slice(1)
+  // Replace underscores and dashes with space
+  output = output.replace(/_/g,' ');
+  output = output.replace(/-/g,' ');
+  return output
+}
+

--- a/datalad_catalog/catalog/display_schema.html
+++ b/datalad_catalog/catalog/display_schema.html
@@ -19,8 +19,12 @@
     <script src="assets/bootstrap-vue.2.21.2.min.js"></script>
 
     <!-- Vue component templates -->
+
+    <!-- ================================= -->
+    <!-- SCHEMA ITEM: FOR SCHEMA RENDERING -->
+    <!-- ================================= -->
     <script type="text/x-template" id="schema-item">
-        <b-card no-body class="border-0">
+        <b-card no-body class="border-0" v-show="item">
           <b-card-body class="pb-0">
             <!-- ITEM TITLE -->
             <b-card-title>
@@ -42,12 +46,12 @@
                 <span v-if="'type' in item">
                   <span v-if="Array.isArray(item.type)">
                     <span v-for="tp in item.type">
-                      <span :style="'background-color:'+type_colors[tp]+';'" class="type-indicator mfont" :id="name+'-'+tp" v-b-tooltip.hover.righttop="'type: '+tp">{{type_icons[tp]}}</span>&nbsp;
+                      <span :style="'background-color:'+type_colors[tp]+';'" class="type-indicator mfont" :id="parent_name+'-'+name+'-'+tp" v-b-tooltip.hover.righttop="'type: '+tp">{{type_icons[tp]}}</span>&nbsp;
                     </span>
                   </span>
-                  <span v-else :style="'background-color:'+type_colors[item.type]+';'" class="type-indicator mfont" :id="name+'-'+item.type" v-b-tooltip.hover.righttop="'type: '+item.type">{{type_icons[item.type]}}</span>
+                  <span v-else :style="'background-color:'+type_colors[item.type]+';'" class="type-indicator mfont" :id="parent_name+'-'+name+'-'+item.type" v-b-tooltip.hover.righttop="'type: '+item.type">{{type_icons[item.type]}}</span>
                 </span>
-                <span v-if="'$ref' in item" :style="'background-color:'+type_colors['$ref']+';'" class="type-indicator mfont" :id="name+'-ref'" v-b-tooltip.hover.righttop="'type: $ref'">{{type_icons['$ref']}}</span>
+                <span v-if="'$ref' in item" :style="'background-color:'+type_colors['$ref']+';'" class="type-indicator mfont" :id="parent_name+'-'+name+'-ref'" v-b-tooltip.hover.righttop="'type: $ref'">{{type_icons['$ref']}}</span>
                 <span v-if="!isschema">
                   <span v-if="requireditems && requireditems.indexOf(name) >= 0" class="type-indicator-required mfont">
                     required</span>
@@ -55,6 +59,8 @@
                     [optional]</span>
                 </span>
               </small>
+              <b-button v-if="isschema" size ="sm" class="pt-0 pb-0 mb-0" variant="outline-dark" @click="$emit('showmetaform')"><i class="fas fa-pen-to-square"></i> Enter metadata</b-button>
+              <span v-if="isschema">&nbsp;<b-button size ="sm" class="pt-0 pb-0 mb-0" variant="outline-dark" @click="$emit('resolveschema')"><i class="fas fa-download"></i> Resolve schema</b-button></span>
             </b-card-title>
             <!-- ITEM ANNOTATIONS AND VALIDATIONS -->
             <b-card-text :class="isschema ? 'mb-1' : 'mb-1 sfont'">
@@ -78,7 +84,7 @@
                       <span v-if="(Array.isArray(item.type) ? item.type : [item.type]).indexOf('array') >= 0">
                         <b-row>
                           <b-col cols="3"><strong>Array Item Type:</strong></b-col>
-                          <b-col>{{item.items.type}}</b-col>
+                          <b-col><span v-if="'items' in item && 'type' in item.items">{{item.items.type}}</span><span v-else><em>unspecified</em></span></b-col>
                         </b-row>
                       </span>
                     </b-container>
@@ -101,37 +107,154 @@
             </b-card-text>
             <!-- OBJECT ITEM: PROPERTIES -->
             <b-card-text>
-              <span v-if="(Array.isArray(item.type) ? item.type : [item.type]).indexOf('object') >= 0 && 'properties' in item">
-                <b-button size="sm" class="pt-0 pb-0" variant="outline-secondary" v-b-toggle="name+'-props'">Properties</b-button>
-                <b-collapse :id="name+'-props'">
-                  <b-card no-body border-variant="default">
-                    <schema-item v-for="key in Object.keys(item.properties)" :name="key" :item="item.properties[key]" :defaults="defaults" :requireditems="item.required" :isschema="false" v-on="$listeners"></schema-item>
-                  </b-card>
-                </b-collapse>
-              </span>
-              <!-- ARRAY ITEM: DETAILS -->
-              <span v-if="(Array.isArray(item.type) ? item.type : [item.type]).indexOf('array') >= 0">
-                <span v-if="item.items.type == 'object'">
-                  <b-button size="sm" class="pt-0 pb-0" variant="outline-secondary" v-b-toggle="name+'items-props'">Array Item Properties</b-button>
-                  <b-collapse :id="name+'items-props'">
+              <span v-if="'type' in item && 'properties' in item">
+                <span v-if="(Array.isArray(item.type) ? item.type : [item.type]).indexOf('object') >= 0">
+                  <b-button size="sm" class="pt-0 pb-0" variant="outline-secondary" v-b-toggle="parent_name+'-'+name+'-props'">Properties</b-button>
+                  <b-collapse :id="parent_name+'-'+name+'-props'">
                     <b-card no-body border-variant="default">
-                      <schema-item v-for="key in Object.keys(item.items.properties)" :name="key" :item="item.items.properties[key]" :defaults="defaults" :requireditems="item.items.required" :isschema="false" v-on="$listeners"></schema-item>
+                      <schema-item v-for="key in Object.keys(item.properties)" :name="key" :parent_name="name" :item="item.properties[key]" :defaults="defaults" :requireditems="item.required" :isschema="false" v-on="$listeners"></schema-item>
                     </b-card>
                   </b-collapse>
+                </span>
+              </span>
+              <!-- ARRAY ITEM: DETAILS -->
+              <span v-if="'type' in item">
+                <span v-if="(Array.isArray(item.type) ? item.type : [item.type]).indexOf('array') >= 0">
+                  <span v-if="'items' in item && 'type' in item.items && item.items.type == 'object'">
+                    <b-button size="sm" class="pt-0 pb-0" variant="outline-secondary" v-b-toggle="parent_name+'-'+name+'items-props'">Array Item Properties</b-button>
+                    <b-collapse :id="parent_name+'-'+name+'items-props'">
+                      <b-card no-body border-variant="default">
+                        <schema-item v-for="key in Object.keys(item.items.properties)" :name="key" :parent_name="name" :item="item.items.properties[key]" :defaults="defaults" :requireditems="item.items.required" :isschema="false" v-on="$listeners"></schema-item>
+                      </b-card>
+                    </b-collapse>
+                  </span>
                 </span>
               </span>
             </b-card-text>
           </b-card-body>
         </b-card>
     </script>
+
+
+    <!-- ================================= -->
+    <!-- T-INPUT: FOR METADATA ITEM INPUT  -->
+    <!-- ================================= -->
+    <script type="text/x-template" id="input-template">
+      <b-form-group
+          :id="obj.input_group_id"
+          :label-for="obj.input_id"
+          ref="formgroup"
+          >
+          <template v-slot:label>
+            <strong>{{(i+1).toString() + '. ' + input_label }}</strong> <i class="fas fa-circle-info text-secondary" v-b-popover.hover.topleft="obj.description"></i> <span class="text-danger" v-if="obj.required">*</span>
+          </template>
+          <span v-if="obj.input_type == 'array'">
+            <b-table ref="itemtable" responsive striped bordered hover small v-bind:items="obj.value"
+              v-bind:fields="array_fields"
+              style="margin-bottom: 5px;">
+              <!-- Options column -->
+              <template #cell(opts)="data">
+                <div style="text-align: right">
+                  <b-button variant="outline-dark" size="sm" @click="addItemModal(data.index)"><i class="fas fa-pen-to-square"></i></b-button>
+                  <b-button variant="outline-dark" size="sm" @click="removeItemModal(data.index)" ><i class="fas fa-trash"></i></b-button>
+                </div>
+              </template>
+            </b-table>
+            <div style="text-align: right;">
+              <b-button variant="outline-dark" size="sm" @click="addItemModal({})">Add item</b-button>
+            </div>
+          </span>
+          <span v-else-if="obj.input_type == 'object'">
+            <b-card no-body>
+              <b-container>
+                <span v-for="ch in obj.children">
+                  <b-row >
+                    <b-col cols="3"><em>{{ch.label}}:</em></b-col>
+                    <b-col>
+                      <span v-if="ch.value">{{ch.value}}</span><span v-else>-</span>
+                    </b-col>
+                  </b-row>
+                </span>
+              </b-container>
+            </b-card>
+            <div style="text-align: right;">
+              <b-button variant="outline-dark" size="sm" @click="addItemModal(obj)">Add/edit data</b-button>
+            </div>
+          </span>
+          <span v-else>
+            <b-form-input :id="obj.input_id" :type="obj.input_type" v-model="obj.value" :placeholder="obj.placeholder" :required="obj.required"></b-form-input>
+          </span>
+          <b-modal ref="additem" @ok="saveItem()" title="Add/Edit item" size="xl" :hideHeaderClose="true" hide-footer>
+            <b-container fluid >
+              <span v-if="obj.input_type == 'array' && obj.children[0]">
+                <span v-if="obj.children[0].input_type == 'object'">
+                  <schema-form :title="obj.label" :form_config="obj.children[0]" :toplevel="false" @closemodal="closeItemModal"></schema-form>
+                </span>
+                <span v-else>
+                  <schema-form :title="obj.label" :form_config="obj" :toplevel="false" @closemodal="closeItemModal"></schema-form>
+                </span>
+              </span>
+              <span v-if="obj.input_type == 'array' && !obj.children[0]">
+                <b-form-group
+                  :id="obj.input_group_id"
+                  :label="obj.form_field"
+                  :label-for="obj.input_id">
+                  <b-form-input :id="obj.input_id" type="text"></b-form-input>
+                </b-form-group>
+              </span>
+              <span v-if="obj.input_type == 'object' && obj.children">
+                <schema-form :title="obj.label" :form_config="obj" :toplevel="false" @closemodal="closeItemModal"></schema-form>
+              </span>
+            </b-container>
+          </b-modal>
+          
+      </b-form-group>
+    </script>
+
+
+    <!-- ================================= -->
+    <!-- SCHEMA-FORM: METADATA INPUT FORM  -->
+    <!-- ================================= -->
+    <script type="text/x-template" id="form-template">
+      <b-card border-variant="dark">
+        <b-card-title>
+          <u>{{title}}</u>
+        </b-card-title>
+        <br>
+        <b-form @submit="onSubmit" @reset="onReset">
+            <span v-for="(field, i) in form_config.children">
+                <t-input ref="forminput" v-bind:obj="field" :i="i"></t-input>
+                <br>
+            </span>
+            <br><br>
+            <div style="text-align: right">
+              <span v-if="toplevel">
+                <b-button type="submit" variant="outline-dark"><i class="fas fa-download"></i> Download metadata</b-button>&nbsp;
+              </span>
+              <span v-else>
+                <b-button type="submit" variant="outline-dark"><i class="far fa-floppy-disk"></i> Save metadata</b-button>&nbsp;
+              </span>
+              <b-button type="reset" variant="outline-dark"><i class="fas fa-arrow-rotate-left"></i> Reset</b-button>
+              <b-button variant="outline-dark" @click="$emit('closemodal')"><i class="fas fa-xmark"></i> Cancel</b-button>
+            </div>
+        </b-form>
+        <br>
+      </b-card>
+    </script>
   </head>
+
+
+  
 
   <!-- ### -->
   <!-- ### -->
   <!-- ### -->
-  <!-- Our application root element -->
+  <!-- ================ -->
+  <!-- MAIN APPLICATION -->
+  <!-- ================ -->
   <body>
     <b-container id="vue_app">
+      <!-- HEADER -->
       <b-container style="margin-top:20px;">
         <b-row align-v="end">
           <b-col cols="9">
@@ -156,6 +279,7 @@
         </b-row>
       </b-container>
       <br>
+      <!-- LIST OF AVAILABLE SCHEMAS + UPLOAD -->
       <b-card no-body border-variant="dark" v-show="schemas_ready">
         <b-card-body>
           <b-card-title>
@@ -167,7 +291,7 @@
                 <b-col>
                   <small>
                     <b-list-group>
-                      <b-list-group-item button v-for="s in Object.keys(schema_files)" @click="selectSchema(s)">{{s}}</b-list-group-item>
+                      <b-list-group-item button v-for="s in Object.keys(schema_files)" @click="selectSchema(s)" :style="s==schema_name ? 'background-color: #fba30454': ''">{{s}}</b-list-group-item>
                     </b-list-group>
                   </small>
                 </b-col>
@@ -178,46 +302,27 @@
           </b-card-text>
         </b-card-body>
       </b-card>
-      
       <br>
 
+      <!-- SELECTED SCHEMA RENDERING -->
       <b-card no-body border-variant="dark" v-show="schemas_ready">
-        <schema-item :name="schema.title" :item="schema" :defaults="defaults" :requireditems="schema.required" :isschema="true" @refselected="selectRefSchema"></schema-item>
-        <!-- <b-card-body>
-          <b-card-title>
-            <u>Schema: {{schema.title}}</u>
-          </b-card-title>
-          <b-card-text class="mb-1">
-            <b-container style="padding-left: 0;">
-              <b-row>
-                <b-col cols="6">
-                  <b-container style="padding-left: 0;">
-                    <span v-for="kw in defaults.schema_keywords.concat(defaults.instance_keywords).concat(defaults.schema_annotations).concat(defaults.additional_keywords)">
-                      <b-row  v-if="kw in schema">
-                        <b-col cols="3"><strong>{{kw}}:</strong></b-col>
-                        <b-col>{{schema[kw]}}</b-col>
-                      </b-row>
-                    </span>
-                  </b-container>
-                </b-col>
-                <b-col>
-                </b-col>
-              </b-row>
-            </b-container>
-          </b-card-text>
-          <b-card-text>
-            <span v-if="schema.type == 'object'">
-              <b-button size="sm" class="pt-0 pb-0" variant="outline-secondary" v-b-toggle="'schema-props'">Properties</b-button>
-              <b-collapse id="schema-props">
-                <b-card no-body border-variant="default">
-                  <schema-item v-for="key in Object.keys(schema.properties)" :name="key" :item="schema.properties[key]" :defaults="defaults" :requireditems="schema.required" :isschema="true"></schema-item>
-                </b-card>
-              </b-collapse>
-            </span>
-          </b-card-text>
-        </b-card-body> -->
+        <schema-item
+          :name="schema.title"
+          :parent_name="''"
+          :item="schema"
+          :defaults="defaults"
+          :requireditems="schema.required"
+          :isschema="true"
+          @refselected="selectRefSchema"
+          @showmetaform="addMetadata(schema)"
+          @resolveschema="getResolvedSchema(schema)"></schema-item>
         <br>
       </b-card>
+      <br>
+
+      <!-- SELECTED SCHEMA FORM INPUT -->
+      <schema-form v-show="show_form" :title="schema.title" :form_config="form_config" :toplevel="true"></schema-form>
+
     </b-container>
     <br><br><br><br>
     <!-- Start running your app -->

--- a/datalad_catalog/catalog/display_schema.html
+++ b/datalad_catalog/catalog/display_schema.html
@@ -59,7 +59,7 @@
                     [optional]</span>
                 </span>
               </small>
-              <b-button v-if="isschema" size ="sm" class="pt-0 pb-0 mb-0" variant="outline-dark" @click="$emit('showmetaform')"><i class="fas fa-pen-to-square"></i> Enter metadata</b-button>
+              <!-- <b-button v-if="isschema" size ="sm" class="pt-0 pb-0 mb-0" variant="outline-dark" @click="$emit('showmetaform')"><i class="fas fa-pen-to-square"></i> Enter metadata</b-button> -->
               <span v-if="isschema">&nbsp;<b-button size ="sm" class="pt-0 pb-0 mb-0" variant="outline-dark" @click="$emit('resolveschema')"><i class="fas fa-download"></i> Resolve schema</b-button></span>
             </b-card-title>
             <!-- ITEM ANNOTATIONS AND VALIDATIONS -->


### PR DESCRIPTION
Building on top of #216.

This PR adds:
- schema $ref resolution, using client-side available schemas (currently for the schemas used in datalad-catalog)
- Translating a resolved schema into a form setup object, from which the metadata entry form is then automatically generated using vue components.

To DO (next PR):
- enable user button to trigger metadata entry
- add ability to upload arbitrary json schemas (draft 2020-12)
- fix data binding from child components to form, as well as form/input data editing