### PR TITLE
BF: Remove imports of datalad.metadata

### DIFF
--- a/datalad_catalog/extractors/datacite_gin.py
+++ b/datalad_catalog/extractors/datacite_gin.py
@@ -17,8 +17,8 @@ from datalad_metalad.extractors.base import (
     DataOutputCategory,
     ExtractorResult,
 )
+from datalad_metalad.extractors.legacy.definitions import vocabulary_id
 from datalad.log import log_progress
-from datalad.metadata.definitions import vocabulary_id
 from datalad.utils import assure_unicode
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 python_requires = >= 3.7
 install_requires =
     datalad >= 0.17
-    datalad-metalad >= 0.4.1
+    datalad-metalad >= 0.4.6
     jsonschema
     pyyaml
     jq


### PR DESCRIPTION
The `datalad.metadata` module was removed from DataLad 0.18 and added to MetaLad 0.4.6. It was imported only once in the catalog codebase (and only to get a single constant). Switching the import will restore compatibility with datalad 0.18.

This also bumps the required patch version of Metalad.

Fixes #238 and should resolve #239.

Note, there are still two matches within the catalog module:
```
❱ git grep datalad.metadata
extractors/datacite_gin.py:lgr = logging.getLogger("datalad.metadata.extractors.datacite_gin")
workflows.py:    return _describe_metadata_elements("datalad.metadata.extractors")
```
The second is I think OK, as it refers to entry point name. Not sure about the first, whether the logger should be renamed to `datalad.catalog.extractors.datacite_gin` or whether it's desirable to keep it. I kept it.