### PR TITLE
Switch MacOS Appveyor builds to Monterey

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -79,7 +79,7 @@ environment:
     # MacOS core tests
     - ID: MacP38core
       DTS: datalad_catalog
-      APPVEYOR_BUILD_WORKER_IMAGE: macOS
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PY: 3.8
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets


### PR DESCRIPTION
Prevents homebrew from stalling while "macOS" currently resolves to outdated Catalina. Fixes #241