### PR TITLE
ENH: don't install jq dependency on windows

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+import platform
+
+if platform.system() == 'Windows':
+    collect_ignore_glob = ["*workflow.py", "*workflows.py"]

--- a/datalad_catalog/tests/test_workflow.py
+++ b/datalad_catalog/tests/test_workflow.py
@@ -16,6 +16,7 @@ from datalad.tests.utils_pytest import (
     assert_equal,
     assert_repo_status,
     skip_if_adjusted_branch,
+    skip_if_on_windows,
 )
 from datalad.api import create, Dataset
 
@@ -297,7 +298,7 @@ super_ds_tree = {
     },
 }
 
-
+@skip_if_on_windows
 @skip_if_adjusted_branch
 @with_tree(tree=super_ds_tree)
 @with_tempfile(mkdir=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     datalad-metalad >= 0.4.6
     jsonschema
     pyyaml
-    jq
+    jq;platform_system!='Windows'
 packages = find:
 include_package_data = True
 


### PR DESCRIPTION
`jq` building is failing on windows during appveyor testing.

- Tried `--ignore=` and `--ignore-glob=` flags unsuccessfully in appveyour `cmd` calls.
- Tried using `git-bash` unsuccessfully.

This PR ensures:
- `jq` is not installed on windows (add below to `setup.cfg`)
```
install_requires
   jq;platform_system!='Windows'
```
- that the `workflows.py` module and related `test_workflow.py` are not collected by pytest on windows (added `conf.py` with content below:)

```python
import platform

if platform.system() == 'Windows':
    collect_ignore_glob = ["*workflow.py", "*workflows.py"]
```