### PR TITLE
Bids translator - fix name & license reporting

### DIFF
--- a/datalad_catalog/translators/bids_dataset_translator.py
+++ b/datalad_catalog/translators/bids_dataset_translator.py
@@ -120,9 +120,14 @@ class BIDSTranslator:
             return None
 
     def get_license(self):
+        url_map = {
+            # only the licenses & links explicitly named in bids spec
+            "PDDL": "https://opendatacommons.org/licenses/pddl/",
+            "CC0": "https://creativecommons.org/publicdomain/zero/1.0/",
+        }
         license_name = self.extracted_metadata.get("License")
         if license_name is not None:
-            return {"name": license_name, "url": ""}
+            return {"name": license_name, "url": url_map.get(license_name, "")}
         return None
 
     def get_authors(self):

--- a/datalad_catalog/translators/bids_dataset_translator.py
+++ b/datalad_catalog/translators/bids_dataset_translator.py
@@ -102,7 +102,7 @@ class BIDSTranslator:
         self.extracted_metadata = self.metadata_record["extracted_metadata"]
 
     def get_name(self):
-        return self.extracted_metadata.get("title", "")
+        return self.extracted_metadata.get("Name", "")
 
     def get_description(self):
         bids_description = self.extracted_metadata.get("description")
@@ -120,10 +120,10 @@ class BIDSTranslator:
             return None
 
     def get_license(self):
-        program = '.license | { "name": .name, "url":  ""}'
-        result = jq.first(program, self.extracted_metadata)
-        # todo check for license info missing
-        return result if len(result) > 0 else None
+        license_name = self.extracted_metadata.get("License")
+        if license_name is not None:
+            return {"name": license_name, "url": ""}
+        return None
 
     def get_authors(self):
         program = (
@@ -199,6 +199,7 @@ class BIDSTranslator:
             "authors": self.get_authors(),
             "keywords": self.get_keywords(),
             "funding": self.get_funding(),
+            "license": self.get_license(),
             "metadata_sources": self.get_metadata_source(),
             "additional_display": self.get_additional_display(),
             "top_display": self.get_top_display(),


### PR DESCRIPTION
In BIDS 1.8.0 and earlier, dataset_description.json has "Name" and "License" keys, and both fields are strings. The [bids_dataset](https://github.com/datalad/datalad-neuroimaging/blob/master/datalad_neuroimaging/extractors/bids_dataset.py) extractor from datalad-neuroimaging keeps these key names.

This PR fixes the field lookup, and also includes the license in the translated output.

The change also lets the extractor add license url for "PDDL" and "CC0" (the two are named explicitly in bids spec, others are allowed but at least we give the two a chance to get translated with a proper URL).