### PR TITLE
ENH: URL parameterization

### DIFF
--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -259,6 +259,11 @@ const datasetView = () =>
           },
         },
         methods: {
+          newTabActivated(newTabIndex, prevTabIndex, bvEvent) {
+            if (newTabIndex == 1) {
+              this.getFiles()
+            }
+          },
           copyCloneCommand(index) {
             // https://stackoverflow.com/questions/60581285/execcommand-is-now-obsolete-whats-the-alternative
             // https://www.sitepoint.com/clipboard-api/
@@ -471,6 +476,10 @@ const datasetView = () =>
           },
         },
         async beforeRouteUpdate(to, from, next) {
+          var has_subdatasets, has_files
+          console.log('\n---BEFORE ROUTE UPDATE---\n')
+          console.log(to.params.tab_name)
+          console.log('\n---BEFORE ROUTE UPDATE---\n')
           this.tabIndex = 0;
           this.subdatasets_ready = false;
           this.dataset_ready = false;
@@ -556,16 +565,62 @@ const datasetView = () =>
             this.$root.selectedDataset.subdatasets_available_count = subdatasets_available.length
             this.$root.selectedDataset.subdatasets_unavailable_count = subdatasets_unavailable.length
             this.subdatasets_ready = true;
+            has_subdatasets = true;
           } else {
             this.$root.selectedDataset.subdatasets = [];
             this.$root.selectedDataset.subdatasets_count = 0
             this.$root.selectedDataset.subdatasets_available_count = 0
             this.$root.selectedDataset.subdatasets_unavailable_count = 0
             this.subdatasets_ready = true;
+            has_subdatasets = false;
+            // Now check file content
+            this.files_ready = false;
+            this.$root.selectedDataset.tree = this.$root.selectedDataset["children"];
+            this.files_ready = true;
+            if (
+              this.$root.selectedDataset.hasOwnProperty("tree") &&
+              this.$root.selectedDataset.tree instanceof Array &&
+              this.$root.selectedDataset.tree.length > 0
+            ) {
+              has_files = true;
+            }
+            else {
+              has_files = false;
+            }
+          }
+          // now set the correct tab:
+          var tab_param = this.$route.params.tab_name;
+          if (!tab_param) {
+            if (has_subdatasets) {
+              this.tabIndex = 0;
+            }
+            else {
+              if (has_files) {
+                this.tabIndex = 1;
+              }
+              else {
+                this.tabIndex = 2;
+              }
+            }
+          }
+          else {
+            tabs = this.$refs['alltabs'].$children.filter(
+              child => typeof child.$vnode.key === 'string' || child.$vnode.key instanceof String
+            ).map(child => child.$vnode.key)
+            selectTab = tabs.indexOf(tab_param)
+            if (selectTab >= 0) {
+              this.tabIndex = selectTab;
+            } else {
+              this.tabIndex = 0;
+            }
           }
           next();
         },
         async created() {
+          var has_subdatasets, has_files
+          console.log('\n---CREATED---\n')
+          console.log(this.$route.params.tab_name)
+          console.log('\n---CREATED---\n')
           file = getFilePath(
             this.$route.params.dataset_id,
             this.$route.params.dataset_version,
@@ -623,12 +678,54 @@ const datasetView = () =>
             this.$root.selectedDataset.subdatasets_available_count = subdatasets_available.length
             this.$root.selectedDataset.subdatasets_unavailable_count = subdatasets_unavailable.length
             this.subdatasets_ready = true;
+            has_subdatasets = true;
           } else {
             this.$root.selectedDataset.subdatasets = [];
             this.$root.selectedDataset.subdatasets_count = 0
             this.$root.selectedDataset.subdatasets_available_count = 0
             this.$root.selectedDataset.subdatasets_unavailable_count = 0
             this.subdatasets_ready = true;
+            has_subdatasets = false;
+            // Now check file content
+            this.files_ready = false;
+            this.$root.selectedDataset.tree = this.$root.selectedDataset["children"];
+            this.files_ready = true;
+            if (
+              this.$root.selectedDataset.hasOwnProperty("tree") &&
+              this.$root.selectedDataset.tree instanceof Array &&
+              this.$root.selectedDataset.tree.length > 0
+            ) {
+              has_files = true;
+            }
+            else {
+              has_files = false;
+            }
+          }
+          // now set the correct tab:
+          var tab_param = this.$route.params.tab_name;
+          if (!tab_param) {
+            if (has_subdatasets) {
+              this.tabIndex = 0;
+            }
+            else {
+              if (has_files) {
+                this.tabIndex = 1;
+              }
+              else {
+                this.tabIndex = 2;
+              }
+            }
+          }
+          else {
+            tabs = this.$refs['alltabs'].$children.filter(
+              child => typeof child.$vnode.key === 'string' || child.$vnode.key instanceof String
+            ).map(child => child.$vnode.key)
+            selectTab = tabs.indexOf(tab_param)
+            if (selectTab >= 0) {
+              this.tabIndex = selectTab;
+            } else {
+              this.tabIndex = 0;
+            }
           }
         },
         mounted() {

--- a/datalad_catalog/catalog/assets/app_router.js
+++ b/datalad_catalog/catalog/assets/app_router.js
@@ -36,7 +36,7 @@ const routes = [
     },
   },
   {
-    path: "/dataset/:dataset_id/:dataset_version",
+    path: "/dataset/:dataset_id/:dataset_version/:tab_name?",
     component: datasetView,
     name: "dataset",
   },

--- a/datalad_catalog/catalog/templates/dataset-template.html
+++ b/datalad_catalog/catalog/templates/dataset-template.html
@@ -245,10 +245,10 @@
           <!-- FILE TREE -->
           <b-tab @click="getFiles">
             <template v-slot:title>
-              <i class="far fa-folder"></i> Files
+              <i class="far fa-folder"></i> Content
             </template>
             <span v-if="files_ready">
-              <span v-if="!selectedDataset.tree || !selectedDataset.tree.length"><em>There are no files listed for the current dataset</em></span>
+              <span v-if="!selectedDataset.tree || !selectedDataset.tree.length"><em>There is no content available for the current dataset</em></span>
               <span v-else>
                 <b-card no-body class="p-2">
                   <ul>
@@ -279,7 +279,7 @@
           </b-tab>
           <!-- PUBLICATIONS -->
           <span v-if="selectedDataset.publications && selectedDataset.publications.length">
-            <b-tab>
+            <b-tab >
               <template v-slot:title>
                 <i class="fas fa-book"></i> Publications
               </template>

--- a/datalad_catalog/catalog/templates/dataset-template.html
+++ b/datalad_catalog/catalog/templates/dataset-template.html
@@ -134,7 +134,7 @@
               <strong>Properties:</strong> <br>
               <span><b-button disabled size="sm" variant="outline-dark">Subdatasets: {{selectedDataset.subdatasets_available_count}}</b-button>&nbsp;</span>
               <span v-if="selectedDataset.top_display && selectedDataset.top_display.length">
-                <span v-for="display_property in selectedDataset.top_display"><b-button disabled size="sm" variant="outline-dark">{{display_property.name}}: {{display_property.value}}</b-button>&nbsp;
+                <span v-for="display_property in selectedDataset.top_display"><b-button disabled size="sm" variant="outline-dark">{{display_property.name}}: {{display_property.value}}</b-button>&nbsp;</span>
               </span>
             </b-card-text>
           </b-col>
@@ -142,9 +142,9 @@
       </b-card-body>
       <!-- BOTTOM SECTION WITH TABS-->
       <b-card-body>
-        <b-tabs card content-class="mt-3" fill active-nav-item-class="font-weight-bold" v-model="tabIndex">
+        <b-tabs card content-class="mt-3" fill active-nav-item-class="font-weight-bold" v-model="tabIndex" @activate-tab="newTabActivated" ref="alltabs">
           <!-- SUBDATASETS -->
-          <b-tab>
+          <b-tab key="subdatasets" ref="tabelement">
             <template v-slot:title>
               <i class="fas fa-list-ol"></i> Subdatasets <span v-if="subdatasets_ready">({{selectedDataset.subdatasets_available_count}})</span>
             </template>
@@ -174,7 +174,6 @@
                       </b-button-group>&nbsp;&nbsp;
                       <b-form-input id="input-1" type="search" placeholder="Search by dataset or author name" required v-model="search_text" ref="text_search_input"></b-form-input>
                     </b-input-group>
-                    
                     </b-col>
                     <b-col md="5">
                       <b-input-group>
@@ -243,7 +242,7 @@
             </span>
           </b-tab>
           <!-- FILE TREE -->
-          <b-tab @click="getFiles">
+          <b-tab @click="getFiles" key="content" ref="tabelement">
             <template v-slot:title>
               <i class="far fa-folder"></i> Content
             </template>
@@ -279,7 +278,7 @@
           </b-tab>
           <!-- PUBLICATIONS -->
           <span v-if="selectedDataset.publications && selectedDataset.publications.length">
-            <b-tab >
+            <b-tab key="publications" ref="tabelement">
               <template v-slot:title>
                 <i class="fas fa-book"></i> Publications
               </template>
@@ -312,7 +311,7 @@
           </span>
           <!-- FUNDING -->
           <span v-if="selectedDataset.funding && selectedDataset.funding.length">
-            <b-tab>
+            <b-tab key="funding" ref="tabelement">
               <template v-slot:title>
                 <i class="fas fa-dollar-sign"></i> Funding
               </template>
@@ -337,7 +336,7 @@
           </span>
           <!-- PROVENANCE -->
           <span v-if="selectedDataset.provenance && selectedDataset.provenance.length">
-            <b-tab>
+            <b-tab key="provenance" ref="tabelement">
               <template v-slot:title>
                 <i class="fas fa-laptop-code"></i> Provenance
               </template>
@@ -449,7 +448,7 @@
           <!-- EXTRA TABS -->
           <span v-if="selectedDataset.additional_display && selectedDataset.additional_display.length">
             <span v-for="new_tab in selectedDataset.additional_display">
-              <b-tab>
+              <b-tab :key="new_tab.name" ref="tabelement">
                 <template v-slot:title>
                   <span v-if="new_tab.icon"><i :class="new_tab.icon"></i></span><span v-else><i class="fas fa-bars"></i></span> {{new_tab.name}}
                 </template>


### PR DESCRIPTION
This PR addresses https://github.com/datalad/datalad-catalog/issues/293

Mainly:
- it is now possible to specify the tab name (e.g. `subdatasets`, `content`, `publications`, etc) as a URL parameter and navigation will ensure that the corresponding tab is opened when opening the dataset page. If a corresponding tab does not exist, the first tab is opened (subdatasets; whether the dataset has subdatasets or not.)
- if a dataset has no subdatasets or content, the next available tab will open when the page is viewed