### PR TITLE
Update datalad.tests.utils imports

### DIFF
--- a/datalad_catalog/extractors/tests/test_datacite_gin.py
+++ b/datalad_catalog/extractors/tests/test_datacite_gin.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import yaml
 from datalad.api import meta_extract
 from datalad.distribution.dataset import Dataset
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_equal,
     with_tempfile,
 )

--- a/datalad_catalog/tests/register.py
+++ b/datalad_catalog/tests/register.py
@@ -1,4 +1,4 @@
-from datalad.tests.utils import assert_result_count
+from datalad.tests.utils_pytest import assert_result_count
 
 
 def register(tmp_path):

--- a/datalad_catalog/tests/test_catalog.py
+++ b/datalad_catalog/tests/test_catalog.py
@@ -12,7 +12,7 @@ from unittest.mock import (
 )
 
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_equal,
     assert_in,
     assert_raises,

--- a/datalad_catalog/tests/test_catalog_arguments.py
+++ b/datalad_catalog/tests/test_catalog_arguments.py
@@ -1,6 +1,6 @@
 import pytest
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_in_results,
     assert_raises,
 )

--- a/datalad_catalog/tests/test_translate.py
+++ b/datalad_catalog/tests/test_translate.py
@@ -12,6 +12,11 @@ from datalad_catalog.webcatalog import (
     Node,
     WebCatalog,
 )
+from datalad.tests.utils_pytest import (
+    assert_in_results,
+    assert_raises,
+    assert_result_count,
+)
 
 tests_path = Path(__file__).resolve().parent
 data_path = tests_path / "data"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,7 +115,7 @@ pygments_style = 'sphinx'
 todo_include_todos = True
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -7,7 +7,6 @@ pyyaml
 # requirements for a development environment
 pytest
 pytest-cov
-nose
 coverage
 
 # requirements for a document building

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ include_package_data = True
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
 devel =
-    nose
     coverage
     pytest
 


### PR DESCRIPTION
As datalad-catalog now uses pytest instead of nose, it should be importing test utilities from `datalad.tests.utils_pytest` instead.