### PR TITLE
Update datalad.tests.utils imports

### DIFF
--- a/datalad_catalog/extractors/tests/test_datacite_gin.py
+++ b/datalad_catalog/extractors/tests/test_datacite_gin.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import yaml
 from datalad.api import meta_extract
 from datalad.distribution.dataset import Dataset
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_equal,
     with_tempfile,
 )

--- a/datalad_catalog/tests/register.py
+++ b/datalad_catalog/tests/register.py
@@ -1,4 +1,4 @@
-from datalad.tests.utils import assert_result_count
+from datalad.tests.utils_pytest import assert_result_count
 
 
 def register(tmp_path):

--- a/datalad_catalog/tests/test_catalog.py
+++ b/datalad_catalog/tests/test_catalog.py
@@ -12,7 +12,7 @@ from unittest.mock import (
 )
 
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_equal,
     assert_in,
     assert_raises,

--- a/datalad_catalog/tests/test_catalog_arguments.py
+++ b/datalad_catalog/tests/test_catalog_arguments.py
@@ -1,6 +1,6 @@
 import pytest
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_in_results,
     assert_raises,
 )

--- a/datalad_catalog/tests/test_translate.py
+++ b/datalad_catalog/tests/test_translate.py
@@ -6,7 +6,7 @@ from datalad_catalog.translate import (
     get_translators,
 )
 from datalad_catalog.utils import read_json_file
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_in_results,
     assert_raises,
     assert_result_count,

--- a/datalad_catalog/workflows.py
+++ b/datalad_catalog/workflows.py
@@ -294,5 +294,5 @@ def _getAvailableExtractors():
     return {
         name: extractor_dict[name]
         for name in extractor_dict.keys()
-        if extractor_dict[name]["load_error"] is None
+        if extractor_dict[name].get("load_error", None) is None
     }

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -7,7 +7,6 @@ pyyaml
 # requirements for a development environment
 pytest
 pytest-cov
-nose
 coverage
 
 # requirements for a document building

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ include_package_data = True
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
 devel =
-    nose
     coverage
     pytest
 


### PR DESCRIPTION
I was under the wrong impression that `datalad-extensions` tests against released tags/packages, but apparently not, so these changes are necessary in `main` as well. Thanks @jwodder.