### PR TITLE
Fix datacite_gin publication doi translation

### DIFF
--- a/datalad_catalog/tests/data/workflow_generated_meta_sub.json
+++ b/datalad_catalog/tests/data/workflow_generated_meta_sub.json
@@ -140,7 +140,7 @@
         {
             "type": "",
             "title": "Sengupta, A., Kaule, F. R., Guntupalli, J. S., Hoffmann, M. B., H\u00e4usler, C., Stadler, J., Hanke, M. (2016). A studyforrest extension, retinotopic mapping and localization of higher visual areas. Scientific Data, 3, 160093.",
-            "doi": "doi:10.1038/sdata.2016.93",
+            "doi": "https://doi.org/10.1038/sdata.2016.93",
             "datePublished": "",
             "publicationOutlet": "",
             "authors": []
@@ -148,7 +148,7 @@
         {
             "type": "",
             "title": "Hanke, M, Adelh\u00f6fer, N, Kottke, D, Iacovella, V, Sengupta, A, Kaule, FR, Nigbur, R, Waite, AQ, Baumgartner, F, Stadler, J (2016). A studyforrest extension, simultaneous fMRI and eye gaze recordings during prolonged natural stimulation. Scientific Data, 3, 160092.",
-            "doi": "doi:10.1038/sdata.2016.92",
+            "doi": "https://doi.org/10.1038/sdata.2016.92",
             "datePublished": "",
             "publicationOutlet": "",
             "authors": []

--- a/datalad_catalog/translators/datacite_gin_translator.py
+++ b/datalad_catalog/translators/datacite_gin_translator.py
@@ -143,7 +143,7 @@ class DataciteTranslator:
             '{"type":"", '
             '"title":$pubin["citation"], '
             '"doi":'
-            '($pubin["id"] | sub("DOI:"; "https://www.doi.org/")), '
+            '($pubin["id"] | sub("(?i)DOI:"; "https://doi.org/")), '
             '"datePublished":"", '
             '"publicationOutlet":"", '
             '"authors": []}]'


### PR DESCRIPTION
This is a small tweak to `datacite_gin_translator` that will:
- Use a case-insensitive replacement (accepting both "doi:" and "DOI:" prefix in translated metadata)
- Return the DOI as `https://doi.org/...` (no www) because this is the format expected by the catalog for nice rendering
- Adjust tests accordingly

FMPOV this should be enough to close #322 as it answers the original problem -- unless you do want to add more formatting rules to JS.

Ping https://github.com/psychoinformatics-de/sfb1451-projects-catalog/issues/23