### PR TITLE
BF: fix file download url rendering

### DIFF
--- a/datalad_catalog/catalog/assets/app_component_item.js
+++ b/datalad_catalog/catalog/assets/app_component_item.js
@@ -120,8 +120,12 @@ Vue.component('tree-item', function (resolve, reject) {
                 return JSON.parse(text);
               },
               getDownloadURL(url_array) {
-                if (url_array && url_array[0]) {
-                  return url_array[0];
+                if (url_array) {
+                  if (Array.isArray(url_array)) {
+                    return url_array[0];
+                  } else {
+                    return url_array;
+                  }
                 } else {
                   return "";
                 }


### PR DESCRIPTION
The previous state resulted in  the download url for a file only containing the first letter of a string (i.e. `url_string[0]`) because it tested for the existence of an array incorrectly. This PR fixes that test and closes https://github.com/datalad/datalad-catalog/issues/342