### PR TITLE
Fine tuning of HTML rendering

### DIFF
--- a/datalad_catalog/catalog/templates/dataset-template.html
+++ b/datalad_catalog/catalog/templates/dataset-template.html
@@ -465,7 +465,18 @@
                     <tbody>
                       <tr v-for="content_key in Object.keys(new_tab.content)">
                          <td><strong>{{ content_key.charAt(0).toUpperCase() + content_key.slice(1) }}</strong></td> 
-                         <td>{{ new_tab.content[content_key] }}</td>  
+                         <td>
+                          <span v-if="!new_tab.content[content_key]"><em>not specified</em></span>
+                          <span v-else-if="Array.isArray(new_tab.content[content_key])">
+                            <span v-for="val in new_tab.content[content_key]">{{val}}<br></span>
+                          </span>
+                          <span v-else-if="typeof new_tab.content[content_key] === 'object'">
+                            <span v-for="k in Object.keys(new_tab.content[content_key])">
+                              <em>{{k}}:</em> {{new_tab.content[content_key][k]}} <br>
+                            </span>
+                          </span>
+                          <span v-else>{{ new_tab.content[content_key] }}</span>
+                         </td>
                       </tr>
                      </tbody>
                   </table>

--- a/datalad_catalog/catalog/templates/dataset-template.html
+++ b/datalad_catalog/catalog/templates/dataset-template.html
@@ -130,7 +130,7 @@
               <b-button pill disabled size="sm" variant="outline-dark" v-for="keyword in selectedDataset.keywords">{{keyword}}</b-button>
             </b-card-text>
 
-            <b-card-text>
+            <b-card-text v-if="selectedDataset.subdatasets_available_count || selectedDataset.top_display">
               <strong>Properties:</strong> <br>
               <span v-if="selectedDataset.subdatasets_available_count"><b-button disabled size="sm" variant="outline-dark">Subdatasets: {{selectedDataset.subdatasets_available_count}}</b-button>&nbsp;</span>
               <span v-if="selectedDataset.top_display && selectedDataset.top_display.length">
@@ -300,7 +300,7 @@
                         <small>
                           Published: {{pub.datePublished}} <br>
                           DOI: <span v-if="pub.doi"><a :href="pub.doi" target="_blank">{{pub.doi.replace("https://doi.org/", "")}}</a></span> <br>
-                          Journal: {{pub.publicationOutlet}}
+                          <span v-if="pub.publicationOutlet">Journal: {{pub.publicationOutlet}}</span>
                         </small>
                       </b-col>
                     </b-row>
@@ -324,8 +324,9 @@
                         <span class="xxlfont"><i class="fas fa-dollar-sign "></i></span>
                       </b-col>
                       <b-col class="text-muted" md="11">
-                        <h5><span v-if="fund.name">{{fund.name}}</span><span v-else><em>(fund name missing)</em></span></h5>
-                        <small><strong>Grant identifier:</strong> {{fund["identifier"]}}<br><strong>Description:</strong> {{fund["description"]}}</small><br>
+                        <h5><span v-if="fund.name">{{fund.name}}</span><span v-else><em>(fund name not specified)</em></span></h5>
+                        <span v-if="fund['identifier']"><small><strong>Grant identifier:</strong> {{fund["identifier"]}}</small><br></span>
+                        <span v-if="fund['description']"><small><strong>Description:</strong> {{fund["description"]}}</small><br></span>
                       </b-col>
                       </b-col>
                     </b-row>


### PR DESCRIPTION
This PR:
- hides fields, including properties, journal, and grant description, if they are not populated, to prevent empty properties from making the rendered page ugly
- improves parsing of objects and arrays in the additional display tab so that they can be rendered in a more visually pleasing way.

**Example 1:**

New:

<img width="1188" alt="Screenshot 2023-09-21 at 22 52 03" src="https://github.com/datalad/datalad-catalog/assets/10141237/1ca93ebf-a886-4002-ab2a-2d728524b5f8">

vs old:
<img width="1134" alt="Screenshot 2023-09-21 at 22 51 52" src="https://github.com/datalad/datalad-catalog/assets/10141237/49a351b6-8856-4fa2-bd51-8ac0cab2e343">


**Example 2:**

New:
<img width="1141" alt="Screenshot 2023-09-21 at 22 51 15" src="https://github.com/datalad/datalad-catalog/assets/10141237/21649586-0f52-45f4-80bf-0aff53227dbe">

vs old
<img width="1140" alt="Screenshot 2023-09-21 at 22 51 29" src="https://github.com/datalad/datalad-catalog/assets/10141237/77db5555-80e5-4844-bff2-fabaf04bc406">

**Example 3:**

New:
<img width="1145" alt="Screenshot 2023-09-21 at 22 50 29" src="https://github.com/datalad/datalad-catalog/assets/10141237/df833b87-0e4f-4369-bd68-44769969abad">

vs old:
<img width="1153" alt="Screenshot 2023-09-21 at 22 50 57" src="https://github.com/datalad/datalad-catalog/assets/10141237/2d16191f-36d9-41b6-b276-db53c4349e35">
