### PR TITLE
Update functionality wrt subdataset display / behaviour / filtering

### DIFF
--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -218,10 +218,17 @@ const datasetView = () =>
                 c.dirs_from_path[c.dirs_from_path.length - 1]
                   .toLowerCase()
                   .indexOf(this.search_text.toLowerCase()) >= 0 ||
-                // || (c.authors.some(e => e.givenName.toLowerCase().indexOf(this.search_text.toLowerCase()) >= 0))
                 c.authors.some(
                   (f) =>
-                    f.name.toLowerCase().indexOf(this.search_text.toLowerCase()) >= 0
+                  f.givenName && f.givenName.toLowerCase().indexOf(this.search_text.toLowerCase()) >= 0 
+                ) ||
+                c.authors.some(
+                  (f) =>
+                  f.familyName && f.familyName.toLowerCase().indexOf(this.search_text.toLowerCase()) >= 0 
+                ) ||
+                c.authors.some(
+                  (f) =>
+                  f.name && f.name.toLowerCase().indexOf(this.search_text.toLowerCase()) >= 0
                 )
               );
             });

--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -333,6 +333,9 @@ const datasetView = () =>
                   dataset_version: objVersion,
                 },
               }
+              // before navigation, clear filtering options
+              this.clearFilters()
+              // now navigate
               if (newBrowserTab) {
                 const routeData = router.resolve(route_info);
                 window.open(routeData.href, '_blank');
@@ -344,6 +347,11 @@ const datasetView = () =>
               console.log(this.$root.subNotAvailable);
               this.$root.$emit("bv::show::modal", "modal-3", "#btnShow");
             }
+          },
+          clearFilters() {
+            this.search_text = ""
+            this.search_tags = []
+            this.clearSearchTagText()
           },
           selectDescription(desc) {
             if (desc.content.startsWith("path:")) {

--- a/datalad_catalog/catalog/assets/app_component_item.js
+++ b/datalad_catalog/catalog/assets/app_component_item.js
@@ -89,6 +89,9 @@ Vue.component('tree-item', function (resolve, reject) {
                       dataset_version: objVersion,
                     },
                   }
+                  // before navigation, clear filter options
+                  this.$emit('clear-filters')
+                  // now navigate
                   if (newBrowserTab) {
                     const routeData = router.resolve(route_info);
                     window.open(routeData.href, '_blank');

--- a/datalad_catalog/catalog/templates/dataset-template.html
+++ b/datalad_catalog/catalog/templates/dataset-template.html
@@ -170,7 +170,7 @@
             <span v-else>
               <span v-if="!subdatasets || !subdatasets.length"><em>There are no subdatasets listed for the current dataset</em></span>
               <span v-else>
-                <b-form>
+                <b-form v-if="subdatasets.length > 3">
                   <b-row>
                     <b-col md="7">
                       <b-input-group>
@@ -246,7 +246,12 @@
                       </b-col>
                       <b-col md="4">
                         <b-card-text>
-                          <span v-for="keyword in ds.keywords"><b-button pill size="sm" class="p-1" variant="outline-dark" @click="addSearchTag(keyword)">{{keyword}}</b-button>&nbsp;</span>
+                          <span v-if="subdatasets.length > 3">
+                            <span v-for="keyword in ds.keywords"><b-button pill size="sm" class="p-1" variant="outline-dark" @click="addSearchTag(keyword)">{{keyword}}</b-button>&nbsp;</span>
+                          </span>
+                          <span v-else>
+                            <span v-for="keyword in ds.keywords"><b-button pill size="sm" class="p-1" variant="outline-secondary">{{keyword}}</b-button>&nbsp;</span>
+                          </span>
                         </b-card-text>
                       </b-col>
                     </b-row>

--- a/datalad_catalog/catalog/templates/dataset-template.html
+++ b/datalad_catalog/catalog/templates/dataset-template.html
@@ -270,7 +270,7 @@
               <span v-else>
                 <b-card no-body class="p-2">
                   <ul>
-                    <tree-item class="item" v-for="item in selectedDataset.tree" :item="item"></tree-item>
+                    <tree-item class="item" v-for="item in selectedDataset.tree" :item="item" @clear-filters="clearFilters"></tree-item>
                   </ul>
                 </b-card>
               </span>

--- a/datalad_catalog/catalog/templates/item-template.html
+++ b/datalad_catalog/catalog/templates/item-template.html
@@ -17,6 +17,6 @@
     </div>
     <!-- Children of an open folder -->
     <ul v-show="isOpen" v-if="isFolder">
-        <tree-item class="item" v-for="(child, index) in item.children" :key="index" :index="index" :item="child"></tree-item>
+        <tree-item class="item" v-for="(child, index) in item.children" :key="index" :index="index" :item="child" v-on="$listeners"></tree-item>
     </ul>
 </li>


### PR DESCRIPTION
This PR:
- Fixes subdataset filtering to filter on `name`, `givenName`, and `familyName` _provided that the property value in each case is not null_
- closes https://github.com/datalad/datalad-catalog/issues/291
- Update subdataset filtering behaviour to only show filtering options when the number of subdatasets > 3. This will hide the filtering options otherwise. Additionally, if the filtering options are hidden, the tags on each subdataset will be deactivated (still visible, but not clickable)
- closes https://github.com/datalad/datalad-catalog/issues/370
- Clears filtering options (filtering text, selected filter tags) when navigating to a subdataset, both from the subdataset view and the content aka file tree view. This prevents the filtering options from remaining and subsequently filtering the subdatasets of the recently selected dataset (after filtering).
- closes https://github.com/datalad/datalad-catalog/issues/372