### PR TITLE
Adds ability for schema_utils to return a base metadata item with specific keys excluded

### DIFF
--- a/datalad_catalog/schema_utils.py
+++ b/datalad_catalog/schema_utils.py
@@ -117,9 +117,10 @@ def get_metadata_item(
     source_version: str,
     path=None,
     required_only: bool = True,
+    exclude_keys: list = [],
 ):
     assert item_type in ("dataset", "file")
-    if item_type == "file" and not path:
+    if item_type == "file" and not path and "path" not in exclude_keys:
         raise ValueError("Path is a required field for item type 'file'")
     meta_item = get_schema_item(
         item_type=item_type,
@@ -129,6 +130,9 @@ def get_metadata_item(
     meta_item[cnst.DATASET_VERSION] = dataset_version
     if item_type == "file":
         meta_item[cnst.PATH] = path
+    for k in exclude_keys:
+        if k in meta_item:
+            del meta_item[k]
     meta_item[cnst.METADATA_SOURCES] = get_metadata_sources(
         source_name,
         source_version,

--- a/datalad_catalog/tests/test_schema_utils.py
+++ b/datalad_catalog/tests/test_schema_utils.py
@@ -125,3 +125,14 @@ def test_get_meta_items():
         path=None,
         required_only=True,
     )
+
+
+def test_exclude_keys():
+    item = get_metadata_item(
+        item_type="file",
+        dataset_id="my_ds_id",
+        dataset_version="my_ds_version",
+        source_name="wackystuff",
+        source_version="wack.point.zero",
+        exclude_keys=["path"],
+    )


### PR DESCRIPTION
This is particularly useful when wanting to get a base structure with minimal fields that also exclude required fields, e.g. a file-level metadata item with all required fields except for 'path' which will be filled at a later stage.