### PR TITLE
Adds ability to specify default tab display via dataset-level config file

### DIFF
--- a/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/config.json
+++ b/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/config.json
@@ -1,0 +1,47 @@
+{
+    "catalog_name": "DataCat",
+    "link_color": "#fba304",
+    "link_hover_color": "#af7714",
+    "social_links": {
+        "about": null,
+        "documentation": "https://docs.datalad.org/projects/catalog/en/latest/",
+        "github": "https://github.com/datalad/datalad-catalog",
+        "mastodon": "https://fosstodon.org/@datalad",
+        "x": "https://x.com/datalad"
+    },
+    "dataset_options": {
+        "include_metadata_export": true,
+        "default_tab": "subdatasets"
+    },
+    "property_sources": {
+        "dataset": {
+            "authors": {
+                "rule": "merge",
+                "source": [
+                    "metalad_studyminimeta"
+                ]
+            },
+            "description": {
+                "rule": "priority",
+                "source": [
+                    "metalad_studyminimeta",
+                    "bids_dataset"
+                ]
+            },
+            "keywords": {
+                "rule": "merge",
+                "source": "any"
+            },
+            "additional_display": {
+                "rule": "merge",
+                "source": []
+            },
+            "top_display": {
+                "rule": "merge",
+                "source": []
+            }
+        },
+        "file": {
+        }
+    }   
+}

--- a/datalad_catalog/catalog/templates/dataset-template.html
+++ b/datalad_catalog/catalog/templates/dataset-template.html
@@ -156,6 +156,41 @@
       <!-- BOTTOM SECTION WITH TABS-->
       <b-card-body>
         <b-tabs card content-class="mt-3" fill active-nav-item-class="font-weight-bold" v-model="tabIndex" @activate-tab="newTabActivated" ref="alltabs">
+          <!-- FILE TREE -->
+          <b-tab @click="getFiles" key="content" ref="tabelement">
+            <template v-slot:title>
+              <i class="far fa-folder"></i> Content
+            </template>
+            <span v-if="files_ready">
+              <span v-if="!selectedDataset.tree || !selectedDataset.tree.length"><em>There is no content available for the current dataset</em></span>
+              <span v-else>
+                <b-card no-body class="p-2">
+                  <ul>
+                    <tree-item class="item" v-for="item in selectedDataset.tree" :item="item" @clear-filters="clearFilters"></tree-item>
+                  </ul>
+                </b-card>
+              </span>
+              <b-modal id="modal-3" size="md"
+              header-bg-variant="light"
+              footer-bg-variant="light"
+              body-bg-variant="light"
+              body-text-variant="dark"
+              ok-only
+              >
+                <template #modal-header="{ close }">
+                  <div class="d-block text-center">
+                    <h3>Dataset not found</h3>
+                    <p class="my-4">The selected dataset is currently not available in the catalog.</p>
+                  </div>
+                </template>
+              </b-modal>
+            </span>
+            <span v-else>
+              <div class="d-flex justify-content-center mb-3">
+                <b-spinner label="Loading..."></b-spinner>
+              </div>
+            </span>
+          </b-tab>
           <!-- SUBDATASETS -->
           <b-tab key="subdatasets" ref="tabelement">
             <template v-slot:title>
@@ -257,41 +292,6 @@
                   </template>
                 </b-card>
               </span>
-            </span>
-          </b-tab>
-          <!-- FILE TREE -->
-          <b-tab @click="getFiles" key="content" ref="tabelement">
-            <template v-slot:title>
-              <i class="far fa-folder"></i> Content
-            </template>
-            <span v-if="files_ready">
-              <span v-if="!selectedDataset.tree || !selectedDataset.tree.length"><em>There is no content available for the current dataset</em></span>
-              <span v-else>
-                <b-card no-body class="p-2">
-                  <ul>
-                    <tree-item class="item" v-for="item in selectedDataset.tree" :item="item" @clear-filters="clearFilters"></tree-item>
-                  </ul>
-                </b-card>
-              </span>
-              <b-modal id="modal-3" size="md"
-              header-bg-variant="light"
-              footer-bg-variant="light"
-              body-bg-variant="light"
-              body-text-variant="dark"
-              ok-only
-              >
-                <template #modal-header="{ close }">
-                  <div class="d-block text-center">
-                    <h3>Dataset not found</h3>
-                    <p class="my-4">The selected dataset is currently not available in the catalog.</p>
-                  </div>
-                </template>
-              </b-modal>
-            </span>
-            <span v-else>
-              <div class="d-flex justify-content-center mb-3">
-                <b-spinner label="Loading..."></b-spinner>
-              </div>
             </span>
           </b-tab>
           <!-- PUBLICATIONS -->


### PR DESCRIPTION
This is a development in response to https://github.com/psychoinformatics-de/sfb1451-projects-catalog/issues/36

This introduces several changes, including:
- the content tab is displayed in position 0
- the subdatasets tab is displayed in position 1
- other standard / non-standard tabs follow in their original order
- if no default tab is specified via the dataset-level config, the content tab is shown
- if a different default tab is provided via dataset-level config, that tab will be shown
- the default tab will be shown on:
  - navigation to dataset via URL
  - navigation to dataset from within the catalog web app
  - navigation to superdataset via user pressing the home button
- a new config file is added for the demo superdataset, with subdatasets as the default tab

Demo at: https://jsheunis.github.io/datalad-catalog-staging

The main things to notice:
- the content tab is in the first position, followed by the subdatasets tab
- the catalog home page dataset displays the subdatasets tab by default (because of the added config file)
- all other dataset pages display the content tab by default