### PR TITLE
Allow python dictionaries to be passed as `metadata` argument

### DIFF
--- a/datalad_catalog/constraints.py
+++ b/datalad_catalog/constraints.py
@@ -22,6 +22,10 @@ from datalad_next.constraints import (
     WithDescription,
 )
 
+from datalad_next.constraints.basic import (
+    EnsureDType,
+)
+
 __docformat__ = "restructuredtext"
 
 
@@ -31,6 +35,10 @@ __docformat__ = "restructuredtext"
 # - a JSON serialized string
 metadata_constraint = WithDescription(
     AnyOf(
+        WithDescription(
+            EnsureDType(dict),
+            error_message="not a valid Python dictionary",
+        ),
         WithDescription(
             EnsureJSON(),
             error_message="not valid JSON content",

--- a/datalad_catalog/tests/test_add.py
+++ b/datalad_catalog/tests/test_add.py
@@ -114,3 +114,28 @@ def test_add_from_json_str(demo_catalog, test_data):
         status="ok",
         path=demo_catalog.location,
     )
+
+
+def test_add_from_dict(demo_catalog):
+    """Add catalog metadata from a json serialized string"""
+    mdata = {
+        "dataset_id": "deabeb9b-7a37-4062-a1e0-8fcef7909609",
+        "dataset_version": "0321dbde969d2f5d6b533e35b5c5c51ac0b15758",
+        "type": "dataset",
+        "metadata_sources": {
+            "key_source_map": {},
+            "sources": [{"source_name": "", "source_version": ""}],
+        },
+    }
+    res = catalog_add(
+        catalog=demo_catalog,
+        metadata=mdata,
+        on_failure="ignore",
+        return_type="list",
+    )
+    assert_in_results(
+        res,
+        action="catalog_add",
+        status="ok",
+        path=demo_catalog.location,
+    )

--- a/datalad_catalog/tests/test_validate.py
+++ b/datalad_catalog/tests/test_validate.py
@@ -89,3 +89,27 @@ def test_validate_without_catalog(demo_catalog, test_data):
         status="error",
         path=Path.cwd(),
     )
+
+
+def test_validate_metadata_dict(demo_catalog):
+    mdata = {
+        "dataset_id": "deabeb9b-7a37-4062-a1e0-8fcef7909609",
+        "dataset_version": "0321dbde969d2f5d6b533e35b5c5c51ac0b15758",
+        "type": "dataset",
+        "metadata_sources": {
+            "key_source_map": {},
+            "sources": [{"source_name": "", "source_version": ""}],
+        },
+    }
+    res = catalog_validate(
+        catalog=demo_catalog,
+        metadata=mdata,
+        on_failure="ignore",
+        return_type="list",
+    )
+    assert_in_results(
+        res,
+        action="catalog_validate",
+        status="ok",
+        path=demo_catalog.location,
+    )


### PR DESCRIPTION
This PR updates `datalad_catalog.constraints.metadata_constraint` to also include a data type constraint for dictionaries so that Python dicts can be passed as the `metadata` argument to `catalog_add` (and `catalog_create` by extension) and `catalog_validate` during package use in Python. Relevant tests are also added.

Closes https://github.com/datalad/datalad-catalog/issues/353