### PR TITLE
Towards more user-friendly navigation using aliases and ID concepts

### DIFF
--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -771,6 +771,23 @@ const datasetView = () =>
             return;
           }
           text = await response.text();
+          response_obj = JSON.parse(text);
+          // if the object.type is alias (i.e. the url parameter is an alias for the dataset)
+          // replace the current route with one containing the actual id and version
+          // TODO: should this be an actual route replace? or should the route with
+          // alias be kept as is and the correct dataset info just fetched from the file
+          // associated with the id and version?
+          if (response_obj["type"] == "redirect") {
+            const replace_route_info = {
+              name: "dataset",
+              params: {
+                dataset_id: response_obj.dataset_id,
+                dataset_version: response_obj.dataset_version,
+              },
+            }
+            router.replace(replace_route_info)
+            return;
+          }
           app.selectedDataset = JSON.parse(text);
           this.dataset_ready = true;
           if (

--- a/datalad_catalog/catalog/assets/app_globals.js
+++ b/datalad_catalog/catalog/assets/app_globals.js
@@ -56,15 +56,24 @@ async function grabSubDatasets(app) {
 function getFilePath(dataset_id, dataset_version, path, ext = ".json") {
   // Get node file location from  dataset id, dataset version, and node path
   // using a file system structure similar to RIA stores
-  file = metadata_dir + "/" + dataset_id + "/" + dataset_version;
-  blob = dataset_id + "-" + dataset_version;
-  if (path) {
-    blob = blob + "-" + path;
+  // - dataset_id is required, all the other parameters are optional
+  // - dataset_id could either be an actual dataset ID or an alias
+  file = metadata_dir + "/" + dataset_id
+  blob = dataset_id
+  if (dataset_version) {
+    file = file + "/" + dataset_version;
+    blob = blob + "-" + dataset_version;
+    // path to file only makes sense with the context of a dataset id AND version
+    if (path) {
+      blob = blob + "-" + path;
+    }
+    blob = md5(blob);
+    blob_parts = [blob.substring(0, SPLIT_INDEX), blob.substring(SPLIT_INDEX)];
+    return file + "/" + blob_parts[0] + "/" + blob_parts[1] + ext;
+  } else {
+    blob = md5(blob);
+    return file + "/" + blob + ext;
   }
-  blob = md5(blob);
-  blob_parts = [blob.substring(0, SPLIT_INDEX), blob.substring(SPLIT_INDEX)];
-  file = file + "/" + blob_parts[0] + "/" + blob_parts[1] + ext;
-  return file;
 }
 
 function getRelativeFilePath(dataset_id, dataset_version, path) {

--- a/datalad_catalog/catalog/assets/app_router.js
+++ b/datalad_catalog/catalog/assets/app_router.js
@@ -36,7 +36,7 @@ const routes = [
     },
   },
   {
-    path: "/dataset/:dataset_id/:dataset_version/:tab_name?",
+    path: "/dataset/:dataset_id/:dataset_version?/:tab_name?",
     component: datasetView,
     name: "dataset",
   },

--- a/datalad_catalog/catalog/metadata/0f66b1ba-e9a9-46fd-b9d9-2e64fe94d307/b454b57ee6b61594659ef53a2d0e1d8b.json
+++ b/datalad_catalog/catalog/metadata/0f66b1ba-e9a9-46fd-b9d9-2e64fe94d307/b454b57ee6b61594659ef53a2d0e1d8b.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "0f66b1ba-e9a9-46fd-b9d9-2e64fe94d307", "dataset_version": "c74b66cf37c0d4ed8914296c6d7792b2d25696aa"}

--- a/datalad_catalog/catalog/metadata/0f66b1ba-e9a9-46fd-b9d9-2e64fe94d307/c74b66cf37c0d4ed8914296c6d7792b2d25696aa/dfb/cb2533c8e474498f9451d63d385c0.json
+++ b/datalad_catalog/catalog/metadata/0f66b1ba-e9a9-46fd-b9d9-2e64fe94d307/c74b66cf37c0d4ed8914296c6d7792b2d25696aa/dfb/cb2533c8e474498f9451d63d385c0.json
@@ -37,7 +37,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/0f66b1ba-e9a9-46fd-b9d9-2e64fe94d307/c74b66cf37c0d4ed8914296c6d7792b2d25696aa/dfb/cb2533c8e474498f9451d63d385c0.json
+++ b/datalad_catalog/catalog/metadata/0f66b1ba-e9a9-46fd-b9d9-2e64fe94d307/c74b66cf37c0d4ed8914296c6d7792b2d25696aa/dfb/cb2533c8e474498f9451d63d385c0.json
@@ -2,6 +2,8 @@
     "dataset_id": "0f66b1ba-e9a9-46fd-b9d9-2e64fe94d307",
     "dataset_version": "c74b66cf37c0d4ed8914296c6d7792b2d25696aa",
     "type": "dataset",
+    "name": "conversion-qa",
+    "alias": "conversion-qa",
     "children": [],
     "url": [
         "https://datapub.fz-juelich.de/studyforrest/studyforrest.ria/0f6/6b1ba-e9a9-46fd-b9d9-2e64fe94d307"
@@ -28,6 +30,14 @@
                 "source_version": "1",
                 "source_parameter": {},
                 "source_time": 1652857127.245356,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/1882e2e6-fbbf-4ade-a65f-3a1615235f51/8d16d5c5c6d981312c9247ecdfbfa2fc.json
+++ b/datalad_catalog/catalog/metadata/1882e2e6-fbbf-4ade-a65f-3a1615235f51/8d16d5c5c6d981312c9247ecdfbfa2fc.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "1882e2e6-fbbf-4ade-a65f-3a1615235f51", "dataset_version": "e5d2f8368fc5f6717d8ef131041c6d943298d0c7"}

--- a/datalad_catalog/catalog/metadata/1882e2e6-fbbf-4ade-a65f-3a1615235f51/e5d2f8368fc5f6717d8ef131041c6d943298d0c7/cc9/4e43626749e8e368f1526a44a8fcf.json
+++ b/datalad_catalog/catalog/metadata/1882e2e6-fbbf-4ade-a65f-3a1615235f51/e5d2f8368fc5f6717d8ef131041c6d943298d0c7/cc9/4e43626749e8e368f1526a44a8fcf.json
@@ -48,7 +48,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/1882e2e6-fbbf-4ade-a65f-3a1615235f51/e5d2f8368fc5f6717d8ef131041c6d943298d0c7/cc9/4e43626749e8e368f1526a44a8fcf.json
+++ b/datalad_catalog/catalog/metadata/1882e2e6-fbbf-4ade-a65f-3a1615235f51/e5d2f8368fc5f6717d8ef131041c6d943298d0c7/cc9/4e43626749e8e368f1526a44a8fcf.json
@@ -43,10 +43,19 @@
                 "source_time": 1652857178.8397892,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
             }
         ]
     },
     "name": "Studyforrest Structural MRI scans",
+    "alias": "3T_structural_mri",
     "description": [
         {
             "source": "datacite_gin",

--- a/datalad_catalog/catalog/metadata/2d05f277-94b0-470b-8e11-4e56691d5b89/78e04a00fedbe3e055f86c2f9127aa48e1133d55/db7/6b24cdbea351b8052cf00c1a1d898.json
+++ b/datalad_catalog/catalog/metadata/2d05f277-94b0-470b-8e11-4e56691d5b89/78e04a00fedbe3e055f86c2f9127aa48e1133d55/db7/6b24cdbea351b8052cf00c1a1d898.json
@@ -2,6 +2,8 @@
     "dataset_id": "2d05f277-94b0-470b-8e11-4e56691d5b89",
     "dataset_version": "78e04a00fedbe3e055f86c2f9127aa48e1133d55",
     "type": "dataset",
+    "name": "retinotopic-maps",
+    "alias": "retinotopic-maps",
     "children": [],
     "url": [
         "http://psydata.ovgu.de/studyforrest/retinotopy/.git",
@@ -37,6 +39,14 @@
                 "source_version": "1",
                 "source_parameter": {},
                 "source_time": 1652857142.5423129,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/2d05f277-94b0-470b-8e11-4e56691d5b89/78e04a00fedbe3e055f86c2f9127aa48e1133d55/db7/6b24cdbea351b8052cf00c1a1d898.json
+++ b/datalad_catalog/catalog/metadata/2d05f277-94b0-470b-8e11-4e56691d5b89/78e04a00fedbe3e055f86c2f9127aa48e1133d55/db7/6b24cdbea351b8052cf00c1a1d898.json
@@ -46,7 +46,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/2d05f277-94b0-470b-8e11-4e56691d5b89/fbbb9ff6740c1924621a49c2a9939130.json
+++ b/datalad_catalog/catalog/metadata/2d05f277-94b0-470b-8e11-4e56691d5b89/fbbb9ff6740c1924621a49c2a9939130.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "2d05f277-94b0-470b-8e11-4e56691d5b89", "dataset_version": "78e04a00fedbe3e055f86c2f9127aa48e1133d55"}

--- a/datalad_catalog/catalog/metadata/3304e775-5f5f-435a-b68e-d98c9f5fb72a/833cd0923c5f6e4ab0d27cc46c21e4a1.json
+++ b/datalad_catalog/catalog/metadata/3304e775-5f5f-435a-b68e-d98c9f5fb72a/833cd0923c5f6e4ab0d27cc46c21e4a1.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "3304e775-5f5f-435a-b68e-d98c9f5fb72a", "dataset_version": "aaac44e047d375cd8f791b1b6fe2b739f02c83b2"}

--- a/datalad_catalog/catalog/metadata/3304e775-5f5f-435a-b68e-d98c9f5fb72a/aaac44e047d375cd8f791b1b6fe2b739f02c83b2/58a/fe240bdb862d1a2bab36fd679efb4.json
+++ b/datalad_catalog/catalog/metadata/3304e775-5f5f-435a-b68e-d98c9f5fb72a/aaac44e047d375cd8f791b1b6fe2b739f02c83b2/58a/fe240bdb862d1a2bab36fd679efb4.json
@@ -2,6 +2,8 @@
     "dataset_id": "3304e775-5f5f-435a-b68e-d98c9f5fb72a",
     "dataset_version": "aaac44e047d375cd8f791b1b6fe2b739f02c83b2",
     "type": "dataset",
+    "name": "cortical-surfaces-freesurfer",
+    "alias": "cortical-surfaces-freesurfer",
     "children": [],
     "url": [
         "http://psydata.ovgu.de/studyforrest/visualrois/.git",
@@ -30,6 +32,14 @@
                 "source_version": "1",
                 "source_parameter": {},
                 "source_time": 1652857136.363641,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/3304e775-5f5f-435a-b68e-d98c9f5fb72a/aaac44e047d375cd8f791b1b6fe2b739f02c83b2/58a/fe240bdb862d1a2bab36fd679efb4.json
+++ b/datalad_catalog/catalog/metadata/3304e775-5f5f-435a-b68e-d98c9f5fb72a/aaac44e047d375cd8f791b1b6fe2b739f02c83b2/58a/fe240bdb862d1a2bab36fd679efb4.json
@@ -39,7 +39,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/3T_structural_mri/37460a809f98d57c82043004953a0f8b.json
+++ b/datalad_catalog/catalog/metadata/3T_structural_mri/37460a809f98d57c82043004953a0f8b.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "1882e2e6-fbbf-4ade-a65f-3a1615235f51", "dataset_version": "e5d2f8368fc5f6717d8ef131041c6d943298d0c7"}

--- a/datalad_catalog/catalog/metadata/3a8648b3-7df8-413f-8efb-4d39040ac174/10e23aafa8271f742e9022a3522d9a88d7fe30cf/e3a/40711c6157b40133f72c8598b00a2.json
+++ b/datalad_catalog/catalog/metadata/3a8648b3-7df8-413f-8efb-4d39040ac174/10e23aafa8271f742e9022a3522d9a88d7fe30cf/e3a/40711c6157b40133f72c8598b00a2.json
@@ -64,7 +64,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/3a8648b3-7df8-413f-8efb-4d39040ac174/10e23aafa8271f742e9022a3522d9a88d7fe30cf/e3a/40711c6157b40133f72c8598b00a2.json
+++ b/datalad_catalog/catalog/metadata/3a8648b3-7df8-413f-8efb-4d39040ac174/10e23aafa8271f742e9022a3522d9a88d7fe30cf/e3a/40711c6157b40133f72c8598b00a2.json
@@ -59,10 +59,19 @@
                 "source_time": 1652857221.792691,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
             }
         ]
     },
     "name": "studyforrest_multires7t",
+    "alias": "7T_multiresolution_fmri",
     "license": {
         "name": "PDDL",
         "url": ""

--- a/datalad_catalog/catalog/metadata/3a8648b3-7df8-413f-8efb-4d39040ac174/6d432172d19c0c59883e75b33d435901.json
+++ b/datalad_catalog/catalog/metadata/3a8648b3-7df8-413f-8efb-4d39040ac174/6d432172d19c0c59883e75b33d435901.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "3a8648b3-7df8-413f-8efb-4d39040ac174", "dataset_version": "10e23aafa8271f742e9022a3522d9a88d7fe30cf"}

--- a/datalad_catalog/catalog/metadata/45b9ab26-07fc-11e8-8c71-f0d5bf7b5561/29dcce2b9477537b433996ebc342c531139e1d87/84f/2098de82902d61066fa8c5aaa0f79.json
+++ b/datalad_catalog/catalog/metadata/45b9ab26-07fc-11e8-8c71-f0d5bf7b5561/29dcce2b9477537b433996ebc342c531139e1d87/84f/2098de82902d61066fa8c5aaa0f79.json
@@ -2,6 +2,8 @@
     "dataset_id": "45b9ab26-07fc-11e8-8c71-f0d5bf7b5561",
     "dataset_version": "29dcce2b9477537b433996ebc342c531139e1d87",
     "type": "dataset",
+    "name": "curated-annotations",
+    "alias": "curated-annotations",
     "children": [],
     "url": [
         "https://datapub.fz-juelich.de/studyforrest/studyforrest.ria/45b/9ab26-07fc-11e8-8c71-f0d5bf7b5561"
@@ -32,6 +34,14 @@
                 "source_version": "1",
                 "source_parameter": {},
                 "source_time": 1652857269.6786208,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/45b9ab26-07fc-11e8-8c71-f0d5bf7b5561/29dcce2b9477537b433996ebc342c531139e1d87/84f/2098de82902d61066fa8c5aaa0f79.json
+++ b/datalad_catalog/catalog/metadata/45b9ab26-07fc-11e8-8c71-f0d5bf7b5561/29dcce2b9477537b433996ebc342c531139e1d87/84f/2098de82902d61066fa8c5aaa0f79.json
@@ -41,7 +41,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/45b9ab26-07fc-11e8-8c71-f0d5bf7b5561/695cf504599be40464b16c52f4ed6f02.json
+++ b/datalad_catalog/catalog/metadata/45b9ab26-07fc-11e8-8c71-f0d5bf7b5561/695cf504599be40464b16c52f4ed6f02.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "45b9ab26-07fc-11e8-8c71-f0d5bf7b5561", "dataset_version": "29dcce2b9477537b433996ebc342c531139e1d87"}

--- a/datalad_catalog/catalog/metadata/5b1081d6-84d7-11e8-b00a-a0369fb55db0/b623351b43eb2715331ac59ad4cf41682e84ff7d/ed9/46e96a98769a46c7cb92b89d071a7.json
+++ b/datalad_catalog/catalog/metadata/5b1081d6-84d7-11e8-b00a-a0369fb55db0/b623351b43eb2715331ac59ad4cf41682e84ff7d/ed9/46e96a98769a46c7cb92b89d071a7.json
@@ -56,7 +56,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/5b1081d6-84d7-11e8-b00a-a0369fb55db0/b623351b43eb2715331ac59ad4cf41682e84ff7d/ed9/46e96a98769a46c7cb92b89d071a7.json
+++ b/datalad_catalog/catalog/metadata/5b1081d6-84d7-11e8-b00a-a0369fb55db0/b623351b43eb2715331ac59ad4cf41682e84ff7d/ed9/46e96a98769a46c7cb92b89d071a7.json
@@ -51,10 +51,19 @@
                 "source_time": 1652857174.37293,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
             }
         ]
     },
     "name": "studyforrest_multires3t",
+    "alias": "studyforrest_multires3t",
     "license": {
         "name": "PDDL (http://opendatacommons.org/licenses/pddl/)",
         "url": ""

--- a/datalad_catalog/catalog/metadata/5b1081d6-84d7-11e8-b00a-a0369fb55db0/de4d5a97f87d6fd5a4e306fd1a3c7461.json
+++ b/datalad_catalog/catalog/metadata/5b1081d6-84d7-11e8-b00a-a0369fb55db0/de4d5a97f87d6fd5a4e306fd1a3c7461.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "5b1081d6-84d7-11e8-b00a-a0369fb55db0", "dataset_version": "b623351b43eb2715331ac59ad4cf41682e84ff7d"}

--- a/datalad_catalog/catalog/metadata/5eaff716-54eb-11e8-803d-a0369f7c647e/72f835ada046bd0479009ea0ff933b30a95b0076/d6c/4a0834f9bbceb0fda32d2abb93f95.json
+++ b/datalad_catalog/catalog/metadata/5eaff716-54eb-11e8-803d-a0369f7c647e/72f835ada046bd0479009ea0ff933b30a95b0076/d6c/4a0834f9bbceb0fda32d2abb93f95.json
@@ -63,10 +63,19 @@
                 "source_time": 1652857264.862466,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
             }
         ]
     },
     "name": "studyforrest_phase2",
+    "alias": "studyforrest_phase2",
     "license": {
         "name": "PDDL",
         "url": ""

--- a/datalad_catalog/catalog/metadata/5eaff716-54eb-11e8-803d-a0369f7c647e/72f835ada046bd0479009ea0ff933b30a95b0076/d6c/4a0834f9bbceb0fda32d2abb93f95.json
+++ b/datalad_catalog/catalog/metadata/5eaff716-54eb-11e8-803d-a0369f7c647e/72f835ada046bd0479009ea0ff933b30a95b0076/d6c/4a0834f9bbceb0fda32d2abb93f95.json
@@ -68,7 +68,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/5eaff716-54eb-11e8-803d-a0369f7c647e/8ca4989589416fc688cf2aef780f55bc.json
+++ b/datalad_catalog/catalog/metadata/5eaff716-54eb-11e8-803d-a0369f7c647e/8ca4989589416fc688cf2aef780f55bc.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "5eaff716-54eb-11e8-803d-a0369f7c647e", "dataset_version": "72f835ada046bd0479009ea0ff933b30a95b0076"}

--- a/datalad_catalog/catalog/metadata/7T_multiresolution_fmri/9528cf4440e65b7f1a5023843a4beefa.json
+++ b/datalad_catalog/catalog/metadata/7T_multiresolution_fmri/9528cf4440e65b7f1a5023843a4beefa.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "3a8648b3-7df8-413f-8efb-4d39040ac174", "dataset_version": "10e23aafa8271f742e9022a3522d9a88d7fe30cf"}

--- a/datalad_catalog/catalog/metadata/7fcd8812-d0fe-11e7-8db2-a0369f7c647e/2ccaa115543c21e6658950d1cb8cc3038f14272f/a31/1d8af93457571bdccbdd53ee77cc5.json
+++ b/datalad_catalog/catalog/metadata/7fcd8812-d0fe-11e7-8db2-a0369f7c647e/2ccaa115543c21e6658950d1cb8cc3038f14272f/a31/1d8af93457571bdccbdd53ee77cc5.json
@@ -2,6 +2,8 @@
     "dataset_id": "7fcd8812-d0fe-11e7-8db2-a0369f7c647e",
     "dataset_version": "2ccaa115543c21e6658950d1cb8cc3038f14272f",
     "type": "dataset",
+    "name": "aggregate",
+    "alias": "aggregate",
     "children": [],
     "url": [
         "http://psydata.ovgu.de/studyforrest/aggregate/.git",
@@ -29,6 +31,14 @@
                 "source_version": "1",
                 "source_parameter": {},
                 "source_time": 1652857130.159643,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/7fcd8812-d0fe-11e7-8db2-a0369f7c647e/2ccaa115543c21e6658950d1cb8cc3038f14272f/a31/1d8af93457571bdccbdd53ee77cc5.json
+++ b/datalad_catalog/catalog/metadata/7fcd8812-d0fe-11e7-8db2-a0369f7c647e/2ccaa115543c21e6658950d1cb8cc3038f14272f/a31/1d8af93457571bdccbdd53ee77cc5.json
@@ -38,7 +38,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/7fcd8812-d0fe-11e7-8db2-a0369f7c647e/abae378ab377b7029525877afb1e41ea.json
+++ b/datalad_catalog/catalog/metadata/7fcd8812-d0fe-11e7-8db2-a0369f7c647e/abae378ab377b7029525877afb1e41ea.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "7fcd8812-d0fe-11e7-8db2-a0369f7c647e", "dataset_version": "2ccaa115543c21e6658950d1cb8cc3038f14272f"}

--- a/datalad_catalog/catalog/metadata/92e65958-4a5a-4c34-a4f4-ee070f7a123b/203aa983534fc2b823ff4777a85f4f80d7a68656/d3e/3a9e40f3f36a138a58e79c33a22de.json
+++ b/datalad_catalog/catalog/metadata/92e65958-4a5a-4c34-a4f4-ee070f7a123b/203aa983534fc2b823ff4777a85f4f80d7a68656/d3e/3a9e40f3f36a138a58e79c33a22de.json
@@ -2,6 +2,8 @@
     "dataset_id": "92e65958-4a5a-4c34-a4f4-ee070f7a123b",
     "dataset_version": "203aa983534fc2b823ff4777a85f4f80d7a68656",
     "type": "dataset",
+    "name": "visual-areas",
+    "alias": "visual-areas",
     "children": [],
     "url": [
         "http://psydata.ovgu.de/studyforrest/visualrois/.git",
@@ -30,6 +32,14 @@
                 "source_version": "1",
                 "source_parameter": {},
                 "source_time": 1652857147.619349,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/92e65958-4a5a-4c34-a4f4-ee070f7a123b/203aa983534fc2b823ff4777a85f4f80d7a68656/d3e/3a9e40f3f36a138a58e79c33a22de.json
+++ b/datalad_catalog/catalog/metadata/92e65958-4a5a-4c34-a4f4-ee070f7a123b/203aa983534fc2b823ff4777a85f4f80d7a68656/d3e/3a9e40f3f36a138a58e79c33a22de.json
@@ -39,7 +39,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/92e65958-4a5a-4c34-a4f4-ee070f7a123b/b91516ac08f564a1ba4266ebf4a751db.json
+++ b/datalad_catalog/catalog/metadata/92e65958-4a5a-4c34-a4f4-ee070f7a123b/b91516ac08f564a1ba4266ebf4a751db.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "92e65958-4a5a-4c34-a4f4-ee070f7a123b", "dataset_version": "203aa983534fc2b823ff4777a85f4f80d7a68656"}

--- a/datalad_catalog/catalog/metadata/aggregate/39adbeb6bc21a3133e5fdcf1ec05d1a0.json
+++ b/datalad_catalog/catalog/metadata/aggregate/39adbeb6bc21a3133e5fdcf1ec05d1a0.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "7fcd8812-d0fe-11e7-8db2-a0369f7c647e", "dataset_version": "2ccaa115543c21e6658950d1cb8cc3038f14272f"}

--- a/datalad_catalog/catalog/metadata/aligned_mri/3bc310d582987a884c2c845e4faef1ec.json
+++ b/datalad_catalog/catalog/metadata/aligned_mri/3bc310d582987a884c2c845e4faef1ec.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "c8ec2919-493b-4af5-9271-cbe9ebd08c43", "dataset_version": "74cd7ec0538448b05fb4d5f91119b279c5e9ab04"}

--- a/datalad_catalog/catalog/metadata/c475969b-2919-57b1-a3e6-71770acaa222/0.1.0/cad/486b905182ab9d7cee7d80ea1173d.json
+++ b/datalad_catalog/catalog/metadata/c475969b-2919-57b1-a3e6-71770acaa222/0.1.0/cad/486b905182ab9d7cee7d80ea1173d.json
@@ -51,7 +51,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/c475969b-2919-57b1-a3e6-71770acaa222/0.1.0/cad/486b905182ab9d7cee7d80ea1173d.json
+++ b/datalad_catalog/catalog/metadata/c475969b-2919-57b1-a3e6-71770acaa222/0.1.0/cad/486b905182ab9d7cee7d80ea1173d.json
@@ -46,10 +46,19 @@
                 "source_time": 1702323824.737152,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
             }
         ]
     },
-    "name": null,
+    "name": "Palmer Penguins",
+    "alias": "palmerpenguins",
     "license": {
         "name": "https://creativecommons.org/publicdomain/zero/1.0/",
         "url": "https://creativecommons.org/publicdomain/zero/1.0/"

--- a/datalad_catalog/catalog/metadata/c475969b-2919-57b1-a3e6-71770acaa222/2d762d47310e4b398e723584e37bd0bc.json
+++ b/datalad_catalog/catalog/metadata/c475969b-2919-57b1-a3e6-71770acaa222/2d762d47310e4b398e723584e37bd0bc.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "c475969b-2919-57b1-a3e6-71770acaa222", "dataset_version": "0.1.0"}

--- a/datalad_catalog/catalog/metadata/c8ec2919-493b-4af5-9271-cbe9ebd08c43/74cd7ec0538448b05fb4d5f91119b279c5e9ab04/b90/35a1c54a01f9ac941818f3f3a73f6.json
+++ b/datalad_catalog/catalog/metadata/c8ec2919-493b-4af5-9271-cbe9ebd08c43/74cd7ec0538448b05fb4d5f91119b279c5e9ab04/b90/35a1c54a01f9ac941818f3f3a73f6.json
@@ -2,6 +2,8 @@
     "dataset_id": "c8ec2919-493b-4af5-9271-cbe9ebd08c43",
     "dataset_version": "74cd7ec0538448b05fb4d5f91119b279c5e9ab04",
     "type": "dataset",
+    "name": "Aligned MRI",
+    "alias": "aligned_mri",
     "children": [],
     "url": [
         "http://psydata.ovgu.de/studyforrest/aligned/.git",
@@ -31,7 +33,16 @@
                 "source_time": 1652857133.28578,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
             }
         ]
     }
 }
+

--- a/datalad_catalog/catalog/metadata/c8ec2919-493b-4af5-9271-cbe9ebd08c43/74cd7ec0538448b05fb4d5f91119b279c5e9ab04/b90/35a1c54a01f9ac941818f3f3a73f6.json
+++ b/datalad_catalog/catalog/metadata/c8ec2919-493b-4af5-9271-cbe9ebd08c43/74cd7ec0538448b05fb4d5f91119b279c5e9ab04/b90/35a1c54a01f9ac941818f3f3a73f6.json
@@ -38,7 +38,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/c8ec2919-493b-4af5-9271-cbe9ebd08c43/b23197118340b9403a16e17af8861a42.json
+++ b/datalad_catalog/catalog/metadata/c8ec2919-493b-4af5-9271-cbe9ebd08c43/b23197118340b9403a16e17af8861a42.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "c8ec2919-493b-4af5-9271-cbe9ebd08c43", "dataset_version": "74cd7ec0538448b05fb4d5f91119b279c5e9ab04"}

--- a/datalad_catalog/catalog/metadata/ceb007ac-ef05-4392-98d2-35c02a774a21/5cdbcb6740de9c334c52f69aea7f957f.json
+++ b/datalad_catalog/catalog/metadata/ceb007ac-ef05-4392-98d2-35c02a774a21/5cdbcb6740de9c334c52f69aea7f957f.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "ceb007ac-ef05-4392-98d2-35c02a774a21", "dataset_version": "688d8d8558fe847f4c1b19aed579745bcd6c7744"}

--- a/datalad_catalog/catalog/metadata/ceb007ac-ef05-4392-98d2-35c02a774a21/688d8d8558fe847f4c1b19aed579745bcd6c7744/261/eb908246b1cc2d056ef050fd8b75a.json
+++ b/datalad_catalog/catalog/metadata/ceb007ac-ef05-4392-98d2-35c02a774a21/688d8d8558fe847f4c1b19aed579745bcd6c7744/261/eb908246b1cc2d056ef050fd8b75a.json
@@ -2,6 +2,8 @@
     "dataset_id": "ceb007ac-ef05-4392-98d2-35c02a774a21",
     "dataset_version": "688d8d8558fe847f4c1b19aed579745bcd6c7744",
     "type": "dataset",
+    "name": "template-transforms",
+    "alias": "template-transforms",
     "children": [],
     "url": [
         "http://psydata.ovgu.de/studyforrest/templatetransforms/.git",
@@ -33,6 +35,14 @@
                 "source_version": "1",
                 "source_parameter": {},
                 "source_time": 1652857139.4177752,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/ceb007ac-ef05-4392-98d2-35c02a774a21/688d8d8558fe847f4c1b19aed579745bcd6c7744/261/eb908246b1cc2d056ef050fd8b75a.json
+++ b/datalad_catalog/catalog/metadata/ceb007ac-ef05-4392-98d2-35c02a774a21/688d8d8558fe847f4c1b19aed579745bcd6c7744/261/eb908246b1cc2d056ef050fd8b75a.json
@@ -42,7 +42,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/conversion-qa/54733551de044407ac7f4e3bc91290d4.json
+++ b/datalad_catalog/catalog/metadata/conversion-qa/54733551de044407ac7f4e3bc91290d4.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "0f66b1ba-e9a9-46fd-b9d9-2e64fe94d307", "dataset_version": "c74b66cf37c0d4ed8914296c6d7792b2d25696aa"}

--- a/datalad_catalog/catalog/metadata/cortical-surfaces-freesurfer/b38b7c3aaa7aedd007533a5babd08ffa.json
+++ b/datalad_catalog/catalog/metadata/cortical-surfaces-freesurfer/b38b7c3aaa7aedd007533a5babd08ffa.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "3304e775-5f5f-435a-b68e-d98c9f5fb72a", "dataset_version": "aaac44e047d375cd8f791b1b6fe2b739f02c83b2"}

--- a/datalad_catalog/catalog/metadata/curated-annotations/dbeb41c7b03da69f096365ba5f63232d.json
+++ b/datalad_catalog/catalog/metadata/curated-annotations/dbeb41c7b03da69f096365ba5f63232d.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "45b9ab26-07fc-11e8-8c71-f0d5bf7b5561", "dataset_version": "29dcce2b9477537b433996ebc342c531139e1d87"}

--- a/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/ddb/8aa081e7afeb3831fe007a3816dce.json
+++ b/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/ddb/8aa081e7afeb3831fe007a3816dce.json
@@ -251,7 +251,7 @@
                 "source_name": "manual_entry",
                 "source_version": "1",
                 "source_parameter": {},
-                "source_time": 1709548638972.9111,
+                "source_time": 1709565468.450221,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
             }

--- a/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/ddb/8aa081e7afeb3831fe007a3816dce.json
+++ b/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/ddb/8aa081e7afeb3831fe007a3816dce.json
@@ -246,10 +246,19 @@
                 "source_time": 1652857119.960284,
                 "agent_name": "Stephan Heunis",
                 "agent_email": "s.heunis@fz-juelich.de"
+            },
+            {
+                "source_name": "manual_entry",
+                "source_version": "1",
+                "source_parameter": {},
+                "source_time": 1709548638972.9111,
+                "agent_name": "Stephan Heunis",
+                "agent_email": "s.heunis@fz-juelich.de"
             }
         ]
     },
     "name": "StudyForrest",
+    "alias": "studyforrest",
     "description": [
         {
             "source": "metalad_studyminimeta",

--- a/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/cc1657d02382ca0a1ca3100843902942.json
+++ b/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/cc1657d02382ca0a1ca3100843902942.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "deabeb9b-7a37-4062-a1e0-8fcef7909609", "dataset_version": "6d7fb68264f9b9951ae141fc830712a8744e3293"}

--- a/datalad_catalog/catalog/metadata/palmerpenguins/66d083a5f519d1fdea831534d187ef5b.json
+++ b/datalad_catalog/catalog/metadata/palmerpenguins/66d083a5f519d1fdea831534d187ef5b.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "c475969b-2919-57b1-a3e6-71770acaa222", "dataset_version": "0.1.0"}

--- a/datalad_catalog/catalog/metadata/retinotopic-maps/29b0ad994a02deeca923988ad80acf10.json
+++ b/datalad_catalog/catalog/metadata/retinotopic-maps/29b0ad994a02deeca923988ad80acf10.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "2d05f277-94b0-470b-8e11-4e56691d5b89", "dataset_version": "78e04a00fedbe3e055f86c2f9127aa48e1133d55"}

--- a/datalad_catalog/catalog/metadata/studyforrest/c3f4ea5fee4b9504ec4718a605d49cd4.json
+++ b/datalad_catalog/catalog/metadata/studyforrest/c3f4ea5fee4b9504ec4718a605d49cd4.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "deabeb9b-7a37-4062-a1e0-8fcef7909609", "dataset_version": "6d7fb68264f9b9951ae141fc830712a8744e3293"}

--- a/datalad_catalog/catalog/metadata/studyforrest_multires3t/e7d094ff09f0602affe30f46cdf19c37.json
+++ b/datalad_catalog/catalog/metadata/studyforrest_multires3t/e7d094ff09f0602affe30f46cdf19c37.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "5b1081d6-84d7-11e8-b00a-a0369fb55db0", "dataset_version": "b623351b43eb2715331ac59ad4cf41682e84ff7d"}

--- a/datalad_catalog/catalog/metadata/studyforrest_phase2/b2405fe766badfea81133768231974d2.json
+++ b/datalad_catalog/catalog/metadata/studyforrest_phase2/b2405fe766badfea81133768231974d2.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "5eaff716-54eb-11e8-803d-a0369f7c647e", "dataset_version": "72f835ada046bd0479009ea0ff933b30a95b0076"}

--- a/datalad_catalog/catalog/metadata/template-transforms/4b421880d1f6f1155f8a3c9f3fd2d236.json
+++ b/datalad_catalog/catalog/metadata/template-transforms/4b421880d1f6f1155f8a3c9f3fd2d236.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "ceb007ac-ef05-4392-98d2-35c02a774a21", "dataset_version": "688d8d8558fe847f4c1b19aed579745bcd6c7744"}

--- a/datalad_catalog/catalog/metadata/visual-areas/4068e6ba9400dd1b95ff8cb302cd3344.json
+++ b/datalad_catalog/catalog/metadata/visual-areas/4068e6ba9400dd1b95ff8cb302cd3344.json
@@ -1,0 +1,1 @@
+{"type": "redirect", "dataset_id": "92e65958-4a5a-4c34-a4f4-ee070f7a123b", "dataset_version": "203aa983534fc2b823ff4777a85f4f80d7a68656"}

--- a/datalad_catalog/catalog/schema/jsonschema_dataset.json
+++ b/datalad_catalog/catalog/schema/jsonschema_dataset.json
@@ -31,6 +31,11 @@
       "title": "Short name",
       "type": "string"
     },
+    "alias": {
+      "description": "An alias of the dataset, used for shortened URL access within the catalog",
+      "title": "Alias",
+      "type": "string"
+    },
     "description": {
       "description": "A 1-2 paragraph description of the dataset",
       "title": "Description",

--- a/datalad_catalog/tests/test_get.py
+++ b/datalad_catalog/tests/test_get.py
@@ -64,24 +64,6 @@ def test_arg_combinations(demo_catalog):
         )
 
 
-def test_get_tree(demo_catalog):
-    """Tests for property: tree"""
-    # placeholder test until the tree functionality is implemented
-    res = catalog_get(
-        catalog=demo_catalog,
-        property="tree",
-        on_failure="ignore",
-        return_type="list",
-    )
-    assert_in_results(
-        res,
-        action="catalog_get",
-        action_property="tree",
-        status="error",
-        path=demo_catalog.location,
-    )
-
-
 def test_get_home(demo_catalog, test_data):
     """Tests for property: home"""
     # test no home spec

--- a/datalad_catalog/tests/test_schema_utils.py
+++ b/datalad_catalog/tests/test_schema_utils.py
@@ -9,6 +9,7 @@ ds = {
     "dataset_id": "",
     "dataset_version": "",
     "name": "",
+    "alias": "",
     "short_name": "",
     "description": "",
     "doi": "",

--- a/datalad_catalog/utils.py
+++ b/datalad_catalog/utils.py
@@ -47,6 +47,16 @@ def md5hash(txt):
     return txt_hash
 
 
+def split_string(input_string, split_length):
+    """
+    Split a string into two parts using a specified
+    length for the first part
+    """
+    path_left = input_string[:split_length]
+    path_right = input_string[split_length:]
+    return path_left, path_right
+
+
 def load_config_file(file: Path):
     """Helper to load content from JSON or YAML file"""
     with open(file) as f:

--- a/tools/create_alias_concept_metadata.py
+++ b/tools/create_alias_concept_metadata.py
@@ -1,0 +1,65 @@
+"""
+With this script you can do the following for an existing catalog:
+- create aliases for datasets from a tsv file (TODO)
+- create alias and concept id metadata files for all datasets
+"""
+from argparse import ArgumentParser
+import json
+from datalad_catalog.constraints import EnsureWebCatalog
+from datalad_catalog.utils import md5hash
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--catalog",
+        type=str,
+        help="Path to the catalog",
+    )
+    parser.add_argument(
+        "--aliases",
+        type=str,
+        help="Path to tsv file with dataset ids and aliases",
+    )
+    args = parser.parse_args()
+    # Ensure is a catalog
+    catalog = EnsureWebCatalog()(args.catalog)
+    # Get report
+    report = catalog.get_catalog_report()
+
+    # Write metadata for all datasets
+    # assumes that datasets have aliases set
+    for d in report.get("datasets", []):
+        # Get latest version
+        current_ds_versions = [
+            dsv for dsv in report.get("versions") if dsv["dataset_id"] == d
+        ]
+        sorted_versions = sorted(
+            current_ds_versions,
+            key=lambda d: d.get("updated_at"),
+            reverse=True,
+        )
+
+        # Dict for metadata
+        redirect_dict = {
+            "type": "redirect",
+            "dataset_id": d,
+            "dataset_version": sorted_versions[0]["dataset_version"],
+        }
+
+        # Create id concept metadata
+        dataset_concept_path = (
+            catalog.metadata_path / d / md5hash(d)
+        ).with_suffix(".json")
+        dataset_concept_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(dataset_concept_path, "w") as f:
+            json.dump(redirect_dict, f)
+
+        # Create alias metadata
+        dataset_alias_path = (
+            catalog.metadata_path
+            / sorted_versions[0]["alias"]
+            / md5hash(sorted_versions[0]["alias"])
+        ).with_suffix(".json")
+        dataset_alias_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(dataset_alias_path, "w") as f:
+            json.dump(redirect_dict, f)


### PR DESCRIPTION
This PR is in response to https://github.com/datalad/datalad-catalog/issues/423, the issue contains a detailed walk-through of the concepts being introduced here. 

The PR has a quite large diff. Firstly, it includes changes to the following core modules:
- `webcatalog`: new methods are added for extracting all IDs in a catalog, and all VERSIONs for respective IDs, including properties like name, alias, and more. This allows users to iterate through a list comprising all catalog datasets (which is necessary for assigning aliases to datasets, and creating alias and ID metadata files for all datasets in a catalog, and also for supporting the upcoming 'tree' command) and allows the 'report' functionality which summarizes some stats of a catalog.
- `node`: adds a method for sorting `metadata_sources` by time, as a proxy for determining a `last_updated` value for a dataset version, which forms part of the output of the new `webcatalog` methods for reporting.
- `get`: adds the property 'report', allowing a summary report of the catalog to be printed out.
- `utils`: changes supporting above methods.
- `tests`: minor changes to allow test success, new tests are TODO.

Then, `name` and `alias` fields were added to the existing metadata of all datasets in the catalog, in preparation for the next step. Then a script was added (and executed) that uses these new python methods to run through all datasets in the demo catalog and then creates associated concept ID and alias metadata files. These files have the format:

```
{
   "type": "redirect",
   "dataset_id": "...",
   "dataset_version": "..."
}
```

and they are located at predictable locations based on the ID or ALIAS of the dataset being accessed. This allows the web app to easily navigate using a friendly URL (e..g. `https://mycatalog.de/dataset/studyforrest_alias` or `https://mycatalog.de/dataset/abcd_id`), which is then routed internally to the correct ID and VERSION metadata file.

Lastly, web asset changes to support this navigation are included.

There are several aspects still to be developed to make this functionality compatible with the full pipeline of catalog creation and entry generation and maintenance. TODO:
- add functionality to always create/update concept and ID metadata files when metadata is added/updated to the catalog
- support a list of versions in the concept id metadata file
- update script to also include assigning `alias` fields to metadata from a tsv file.