### PR TITLE
Remove void statement which can cause errors

### DIFF
--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -499,8 +499,6 @@ const datasetView = () =>
                 } else {
                   return null
                 }
-                selectedDS.additional_display[0]["content"]["homepage"]["@value"]
-                return 
               // "spatialCoverage", // Text or Place
               // "temporalCoverage", // Text
               // "variableMeasured", // Text or PropertyValue


### PR DESCRIPTION
I think (but please verify) that these two lines should be removed, because the actual handling of "homepage" seems to happen a few lines above, and uses optional chaining (`?.`). If left in, they cause errors when the additional display does not contain "homepage".

This should fix #450 