### PR TITLE
Fix notebook handling

### DIFF
--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -758,9 +758,9 @@ const datasetView = () =>
           openWithBinder(dataset_url, current_dataset) {
             const environment_url =
               "https://mybinder.org/v2/gh/datalad/datalad-binder/main";
-            const content_url = "https://github.com/jsheunis/datalad-notebooks";
-            const content_repo_name = "datalad-notebooks";
-            const notebook_name = "download_data_with_datalad_python.ipynb";
+            var content_url = "https://github.com/jsheunis/datalad-notebooks";
+            var content_repo_name = "datalad-notebooks";
+            var notebook_name = "download_data_with_datalad_python.ipynb";
             if (current_dataset.hasOwnProperty("notebooks") && current_dataset.notebooks.length > 0) {
               // until including the functionality to select from multiple notebooks in a dropdown, just select the first one
               notebook = current_dataset.notebooks[0]

--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -225,7 +225,7 @@ const datasetView = () =>
               }
               // Show / hide binder button: if disp_dataset.url exists OR if dataset has a notebook specified in metadata
               disp_dataset.show_binder_button = false
-              if ( disp_dataset.url || dataset.hasOwnProperty("notebooks") && current_dataset.notebooks.length > 0 ) {
+              if ( disp_dataset.url || disp_dataset.hasOwnProperty("notebooks") && disp_dataset.notebooks.length > 0 ) {
                 disp_dataset.show_binder_button = true
               }
 

--- a/tools/create_alias_concept_metadata.py
+++ b/tools/create_alias_concept_metadata.py
@@ -3,6 +3,7 @@ With this script you can do the following for an existing catalog:
 - create aliases for datasets from a tsv file
 - create alias and concept id metadata files for all datasets
 """
+
 from argparse import ArgumentParser
 import csv
 import json


### PR DESCRIPTION
This PR fixes errors in handling custom notebook information (the ability was introduced as part of #440). No tracing issue because the fixes are small.

It also fixes a black formatting inconsistency picked by CI (2024 stable style requires empty line after module docstring) also seen in a few recent PRs.

See Individual commits for details. 