### PR TITLE
Add caching headers to `fetch` calls that get json metadata

### DIFF
--- a/datalad_catalog/catalog/assets/app.js
+++ b/datalad_catalog/catalog/assets/app.js
@@ -26,7 +26,7 @@ var datacat = new Vue({
   },
   beforeCreate() {
     console.debug("Executing lifecycle hook: beforeCreate")
-    fetch(config_file)
+    fetch(config_file, {cache: "no-cache"})
       .then((response) => {
         if (response.ok) {
           return response.json();

--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -293,7 +293,7 @@ const datasetView = () =>
               scripttag.textContent = JSON.stringify(pruneObject(obj));
 
               dataset_id_path = getFilePath(this.selectedDataset.dataset_id)
-              fetch(dataset_id_path)
+              fetch(dataset_id_path, {cache: "no-cache"})
                 .then((response) => {
                   if(response.status == 404) {
                     this.selectedDataset.has_id_path = false
@@ -839,7 +839,7 @@ const datasetView = () =>
             this.files_ready = false;
             file_hash = this.selectedDataset.children;
             file = metadata_dir + "/" + file_hash + ".json";
-            response = await fetch(file);
+            response = await fetch(file, {cache: "no-cache"});
             text = await response.text();
             obj = JSON.parse(text);
             this.$root.selectedDataset.tree = obj["children"];
@@ -909,7 +909,7 @@ const datasetView = () =>
           this.subdatasets_ready = false;
           this.dataset_ready = false;
           file = getFilePath(to.params.dataset_id, to.params.dataset_version, null);
-          response = await fetch(file);
+          response = await fetch(file, {cache: "no-cache"});
           text = await response.text();
           response_obj = JSON.parse(text);
           // if the object.type is redirect (i.e. the url parameter is an alias for or ID
@@ -1051,7 +1051,7 @@ const datasetView = () =>
           this.$root.selectedDataset.available_tabs = available_tabs_lower
           // Now get dataset config if it exists
           dataset_config_path = metadata_dir + "/" + sDs.dataset_id + "/" + sDs.dataset_version + "/config.json";
-          configresponse = await fetch(dataset_config_path);
+          configresponse = await fetch(dataset_config_path, {cache: "no-cache"});
           if (configresponse.status == 404) {
             this.$root.selectedDataset.config = {};
           } else {
@@ -1076,7 +1076,7 @@ const datasetView = () =>
           console.debug("Executing lifecycle hook: created")
           // fetch superfile in order to set id and version on $root
           homefile = metadata_dir + "/super.json";
-          homeresponse = await fetch(homefile);
+          homeresponse = await fetch(homefile, {cache: "no-cache"});
           if (homeresponse.status == 404) {
             this.$root.home_dataset_id = null;
             this.$root.home_dataset_version = null;
@@ -1092,7 +1092,7 @@ const datasetView = () =>
             null
           );
           var app = this.$root;
-          response = await fetch(file);
+          response = await fetch(file, {cache: "no-cache"});
           // Reroute to 404 if the dataset file is not found
           if (response.status == 404) {
             router.push({
@@ -1206,7 +1206,7 @@ const datasetView = () =>
           this.$root.selectedDataset.available_tabs = available_tabs_lower
           // Now get dataset config if it exists
           dataset_config_path = metadata_dir + "/" + sDs.dataset_id + "/" + sDs.dataset_version + "/config.json";
-          configresponse = await fetch(dataset_config_path);
+          configresponse = await fetch(dataset_config_path, {cache: "no-cache"});
           if (configresponse.status == 404) {
             this.$root.selectedDataset.config = {};
           } else {

--- a/datalad_catalog/catalog/assets/app_component_item.js
+++ b/datalad_catalog/catalog/assets/app_component_item.js
@@ -119,7 +119,7 @@ Vue.component('tree-item', function (resolve, reject) {
                 obj.dataset_version = this.$root.selectedDataset.dataset_version;
                 file = getFilePath(obj.dataset_id, obj.dataset_version, obj.path);
                 try {
-                  response = await fetch(file);
+                  response = await fetch(file, {cache: "no-cache"});
                   text = await response.text();
                 } catch (error) {
                   console.error(error);

--- a/datalad_catalog/catalog/assets/app_globals.js
+++ b/datalad_catalog/catalog/assets/app_globals.js
@@ -37,7 +37,7 @@ async function grabSubDatasets(app) {
       id_and_version = subds.dataset_id + "-" + subds.dataset_version;
       subds_file = getFilePath(subds.dataset_id, subds.dataset_version, null);
       try {
-        subds_response = await fetch(subds_file);
+        subds_response = await fetch(subds_file, {cache: "no-cache"});
         subds_text = await subds_response.text();
       } catch (e) {
         console.error(e);

--- a/datalad_catalog/catalog/assets/app_router.js
+++ b/datalad_catalog/catalog/assets/app_router.js
@@ -10,31 +10,28 @@ const routes = [
     beforeEnter: (to, from, next) => {
       console.debug("Executing navigation guard: beforeEnter - route '/')")
       const superfile = metadata_dir + "/super.json";
-      // https://www.dummies.com/programming/php/using-xmlhttprequest-class-properties/
-      var rawFile = new XMLHttpRequest();
-      rawFile.onreadystatechange = function () {
-        if (rawFile.readyState === 4) {
-          if (rawFile.status === 200 || rawFile.status == 0) {
-            var allText = rawFile.responseText;
-            superds = JSON.parse(allText);
-            router.push({
-              name: "dataset",
-              params: {
-                dataset_id: superds["dataset_id"],
-                dataset_version: superds["dataset_version"],
-              },
-              query: to.query,
-            });
-            next();
-          } else if (rawFile.status === 404) {
-            router.push({ name: "404" });
-          } else {
-            // TODO: figure out what to do here
-          }
+      fetch(superfile, {cache: "no-cache"})
+      .then((response) => {
+        if(response.status == 404) {
+          router.push({ name: "404" });
+          next();
         }
-      };
-      rawFile.open("GET", superfile, false);
-      rawFile.send();
+        return response.text()
+      }).then((text) => {
+        superds = JSON.parse(text);
+        router.push({
+          name: "dataset",
+          params: {
+            dataset_id: superds["dataset_id"],
+            dataset_version: superds["dataset_version"],
+          },
+          query: to.query,
+        });
+        next();
+      })
+      .catch(error => {
+        console.error(error)
+      })
     },
   },
   {

--- a/datalad_catalog/catalog/index.html
+++ b/datalad_catalog/catalog/index.html
@@ -5,6 +5,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <!-- Caching meta tags -->
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
 
     <link rel="icon" href="/assets/favicon/favicon.ico" type="image/x-icon">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon/favicon-32x32.png">


### PR DESCRIPTION
These headers specify `cache: no-cache` so that the fetch call will not rely on cached metadata which could be outdated. This is especially needed when navigating to a catalog's homepage, which which fetches the catalog's `super.json` file to look for the home page dataset to display, which could change often.

In addition, the outdated `XMLHttpRequest` call is replaced with a `fetch`.