### PR TITLE
Fix circular import error with loaded datalad-next

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -197,8 +197,8 @@ test_script:
   - cmd: md __testhome__
   - sh: mkdir __testhome__
   - cd __testhome__
-  - cmd: python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_catalog --pyargs %DTS%
-  - sh:  python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_catalog --pyargs ${DTS}
+  - cmd: python -m pytest -s -v -m "not (turtle)" --cov=datalad_catalog --pyargs %DTS%
+  - sh:  python -m pytest -s -v -m "not (turtle)" --cov=datalad_catalog --pyargs ${DTS}
 
 
 after_test:


### PR DESCRIPTION
This PR fixes a circular import error that occurs when datalad-next is loaded and tests are patched. The error is described in PR [datalad-next #716](https://github.com/datalad/datalad-next/pull/716).

The reason for the import error is that importing `datalad_catalog.add` from the module-level context in `datalad_catalog.tests.test_add`, will import `datalad_next`, which will in turn import certain tests, which import from `datalad.api`, which will trigger the extension-api generation process, which tries to import and process
`datalad_catalog.add` again (which is not yet completely loaded).
