### PR TITLE
Add ability to specify binder environment url along with notebook

### DIFF
--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -225,7 +225,7 @@ const datasetView = () =>
               }
               // Show / hide binder button: if disp_dataset.url exists OR if dataset has a notebook specified in metadata
               disp_dataset.show_binder_button = false
-              if ( disp_dataset.url || disp_dataset.hasOwnProperty("notebooks") && disp_dataset.notebooks.length > 0 ) {
+              if ( disp_dataset.url || dataset.hasOwnProperty("notebooks") && dataset.notebooks.length > 0 ) {
                 disp_dataset.show_binder_button = true
               }
 
@@ -754,18 +754,24 @@ const datasetView = () =>
             window.open(url);
           },
           openWithBinder(dataset_url, current_dataset) {
-            const environment_url =
+            var environment_url =
               "https://mybinder.org/v2/gh/datalad/datalad-binder/main";
             var content_url = "https://github.com/jsheunis/datalad-notebooks";
             var content_repo_name = "datalad-notebooks";
             var notebook_name = "download_data_with_datalad_python.ipynb";
+            var has_custom_notebook = false;
             if (current_dataset.hasOwnProperty("notebooks") && current_dataset.notebooks.length > 0) {
               // until including the functionality to select from multiple notebooks in a dropdown, just select the first one
+              has_custom_notebook = true
               notebook = current_dataset.notebooks[0]
               content_url = notebook.git_repo_url.replace(".git", "")
               content_repo_name = content_url.substring(content_url.lastIndexOf('/') + 1)
-              notebook_name = notebook.notebook_path
+              notebook_name = escapeHTML(notebook.notebook_path)
+              if (notebook.hasOwnProperty("binder_env_url") && notebook["binder_env_url"]) {
+                environment_url = notebook["binder_env_url"]
+              }
             }
+
             binder_url =
               environment_url +
               "?urlpath=git-pull%3Frepo%3D" +
@@ -773,10 +779,14 @@ const datasetView = () =>
               "%26urlpath%3Dnotebooks%252F" +
               content_repo_name +
               "%252F" +
-              notebook_name +
-              "%3Frepourl%3D%22" +
-              dataset_url +
-              "%22";
+              notebook_name;
+
+            if (!has_custom_notebook) {
+              binder_url = binder_url +
+                "%3Frepourl%3D%22" +
+                dataset_url +
+                "%22"
+            }
             window.open(binder_url);
           },
           sortByName() {

--- a/datalad_catalog/catalog/assets/app_globals.js
+++ b/datalad_catalog/catalog/assets/app_globals.js
@@ -126,3 +126,7 @@ function pruneObject(obj) {
   return newObj;
 }
 
+
+function escapeHTML(str){
+    return new Option(str).innerHTML;
+}

--- a/datalad_catalog/catalog/metadata/c475969b-2919-57b1-a3e6-71770acaa222/0.1.0/cad/486b905182ab9d7cee7d80ea1173d.json
+++ b/datalad_catalog/catalog/metadata/c475969b-2919-57b1-a3e6-71770acaa222/0.1.0/cad/486b905182ab9d7cee7d80ea1173d.json
@@ -201,5 +201,12 @@
                 }
             }
         }
+    ],
+    "notebooks": [
+        {
+            "git_repo_url": "https://github.com/mcnakhaee/palmerpenguins",
+            "notebook_path": "notebooks/example.ipynb",
+            "binder_env_url": "https://mybinder.org/v2/gh/datalad/datalad-binder/enhs"
+        }
     ]
 }

--- a/datalad_catalog/catalog/schema/jsonschema_dataset.json
+++ b/datalad_catalog/catalog/schema/jsonschema_dataset.json
@@ -308,6 +308,11 @@
             "description": "The path to the notebook, relative to the repository root, including the filename and extension",
             "title": "Notebook path",
             "type": "string"
+          },
+          "binder_env_url": {
+            "description": "The URL to a myBinder base environment that is built up by specifying a git repository URL and branch/tag name, see https://mybinder.org. The public repository should contain the Binder environment configuration as specified by https://mybinder.readthedocs.io/en/latest/using/config_files.html#. An example: https://mybinder.org/v2/gh/datalad/datalad-binder/main",
+            "title": "Binder repo URL",
+            "type": "string"
           }
         },
         "required": ["git_repo_url", "notebook_path"]


### PR DESCRIPTION
Closes https://github.com/datalad/datalad-catalog/issues/459

- The 'binder_env_url' field is introduced into the 'notebooks' field of the dataset schema, to allow a binder environment to be specified along with a notebook.
- This URL will replace the base environment url that was previously hardcoded; while the base url remains as the default.
- A fix is added to the flag that sets whether the binder button is displayed or not.
- The palmerpenguins dataset metadata is updated to include some arbitrary binder_env_url in order to test the new functionality
- An HTMLescape function is added to encode notebook names with e.g. spaces correctly for HTML.