### PR TITLE
Add missing `/` to `Full URL` 

### DIFF
--- a/datalad_catalog/catalog/templates/dataset-template.html
+++ b/datalad_catalog/catalog/templates/dataset-template.html
@@ -173,7 +173,7 @@
               <b-row>
                 <b-col cols="11" style="overflow: auto; white-space: nowrap;">
                   <code id="full_url">
-                    {{window.location.origin + 'dataset/' + selectedDataset.dataset_id + '/' + selectedDataset.dataset_version}}
+                    {{window.location.origin + '/dataset/' + selectedDataset.dataset_id + '/' + selectedDataset.dataset_version}}
                   </code>
                 </b-col>
                 <b-col cols="1">


### PR DESCRIPTION
Fixes #466 

This PR adds a missing `/` to the content of `Full URL` in the share-pop up of a dataset landing page in the catalog