### PR TITLE
Add safety checks to translators

### DIFF
--- a/datalad_catalog/translators/bids_dataset_translator.py
+++ b/datalad_catalog/translators/bids_dataset_translator.py
@@ -143,12 +143,12 @@ class BIDSTranslator(TranslatorImplementationBase):
             '"email":"", "honorificSuffix":"", "identifiers":[]}]'
         )
         result = jq.first(program, self.extracted_metadata)
-        return result if len(result) > 0 else None
-
+        return result if result is not None and len(result) > 0 else None
+    
     def get_keywords(self):
         program = ". as $parent | .entities.task + .variables.dataset"
         result = jq.first(program, self.extracted_metadata)
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def get_funding(self):
         program = (
@@ -156,7 +156,7 @@ class BIDSTranslator(TranslatorImplementationBase):
             '{"name": "", "grant":"", "description":$fund}]'
         )
         result = jq.first(program, self.extracted_metadata)
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def get_publications(self):
         program = (
@@ -170,12 +170,12 @@ class BIDSTranslator(TranslatorImplementationBase):
             '"authors": []}]'
         )
         result = jq.first(program, self.extracted_metadata)
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def get_additional_display(self):
         program = '[{"name": "BIDS", "content": .entities}]'
         result = jq.first(program, self.extracted_metadata)
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def get_top_display(self):
         program = (
@@ -185,7 +185,7 @@ class BIDSTranslator(TranslatorImplementationBase):
             '{"name": "Runs", "value": (.entities.run | length)}]'
         )
         result = jq.first(program, self.extracted_metadata)
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def translate(self):
         translated_record = {

--- a/datalad_catalog/translators/datacite_gin_translator.py
+++ b/datalad_catalog/translators/datacite_gin_translator.py
@@ -117,7 +117,7 @@ class DataciteTranslator(TranslatorImplementationBase):
         program = '.license | { "name": .name, "url": .url}'
         result = jq.first(program, self.extracted_metadata)
         # todo check for license info missing
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def get_authors(self):
         program = (
@@ -130,7 +130,7 @@ class DataciteTranslator(TranslatorImplementationBase):
             "else null end]"
         )
         result = jq.first(program, self.extracted_metadata)
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def get_keywords(self):
         return self.extracted_metadata.get("keywords")
@@ -141,7 +141,7 @@ class DataciteTranslator(TranslatorImplementationBase):
             '{"name": $element, "identifier": "", "description": ""}]'
         )
         result = jq.first(program, self.extracted_metadata)
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def get_publications(self):
         program = (
@@ -155,7 +155,7 @@ class DataciteTranslator(TranslatorImplementationBase):
             '"authors": []}]'
         )
         result = jq.first(program, self.extracted_metadata)
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def translate(self):
         translated_record = {

--- a/datalad_catalog/translators/metalad_core_translator.py
+++ b/datalad_catalog/translators/metalad_core_translator.py
@@ -140,7 +140,7 @@ class CoreTranslator(TranslatorImplementationBase):
             '"dirs_from_path": []}]'
         )
         result = jq.first(program, self.graph)
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def get_file_url(self):
         program = ".distribution? | .url?"

--- a/datalad_catalog/translators/metalad_studyminimeta_translator.py
+++ b/datalad_catalog/translators/metalad_studyminimeta_translator.py
@@ -168,7 +168,7 @@ class MinimetaTranslator(TranslatorImplementationBase):
             '{"name": .name, "identifier": "", "description": ""}]'
         )
         result = jq.first(program, self.graph)  #  [] if nothing found
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def get_publications(self):
         if self.combinedpersonspubs is not None:
@@ -194,7 +194,7 @@ class MinimetaTranslator(TranslatorImplementationBase):
             '"dataset_path": .name, "dirs_from_path": []}]'
         )
         result = jq.first(program, self.graph)  #  [] if nothing found
-        return result if len(result) > 0 else None
+        return result if result is not None and len(result) > 0 else None
 
     def translate(self):
         translated_record = {


### PR DESCRIPTION
For cases where jq returns None instead of expected empty list.

It's unnecessary code duplication, but in the light of https://github.com/datalad/datalad-catalog/issues/470 I think this will be fine.

Closes https://github.com/datalad/datalad-catalog/issues/461