### PR TITLE
Introduce `download_url` and `homepage_url` with associated buttons

### DIFF
--- a/datalad_catalog/catalog/assets/app_component_dataset.js
+++ b/datalad_catalog/catalog/assets/app_component_dataset.js
@@ -157,6 +157,8 @@ const datasetView = () =>
               disp_dataset.show_cite = true; // 'Cite' button
               disp_dataset.show_export = true; // 'Export metadata' button
               disp_dataset.show_access_request = true; // 'Request access' button
+              disp_dataset.show_homepage = true; // 'Homepage' button
+              disp_dataset.show_download = true; // 'Download' button
               
               // URL (this is the field for the datalad dataset url to clone from)
               // If URL does not exist, several buttons cannot be shown
@@ -210,6 +212,31 @@ const datasetView = () =>
               }
               // Show cite button: if the dataset.doi exists AND config specifies (or is missing)
               disp_dataset.show_cite = dataset.doi ? (dataset_options.include_cite ?? true) : false
+
+              // Show homepage button: if the dataset.homepage_url exists AND config specifies (or is missing)
+              if (dataset.hasOwnProperty("homepage_url")) {
+                if (
+                  (dataset["homepage_url"] instanceof Array || Array.isArray(dataset["homepage_url"])) &&
+                  dataset["homepage_url"].length > 0
+                ) {
+                  disp_dataset.homepage_url = dataset.homepage_url[0];
+                } else {
+                  disp_dataset.homepage_url = dataset.homepage_url;
+                }
+              }
+              disp_dataset.show_homepage = disp_dataset.homepage_url ? (dataset_options.include_homepage ?? true) : false
+              // Show download button: if the dataset.download_url exists AND config specifies (or is missing)
+              if (dataset.hasOwnProperty("download_url")) {
+                if (
+                  (dataset["download_url"] instanceof Array || Array.isArray(dataset["download_url"])) &&
+                  dataset["download_url"].length > 0
+                ) {
+                  disp_dataset.download_url = dataset.download_url[0];
+                } else {
+                  disp_dataset.download_url = dataset.download_url;
+                }
+              }
+              disp_dataset.show_download = disp_dataset.download_url ? (dataset_options.include_download ?? true) : false
               // Show export button: if config specifies (or is missing)
               disp_dataset.show_export = dataset_options.include_metadata_export ?? true
               // Show/hide config for "Request access" button:

--- a/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/config.json
+++ b/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/config.json
@@ -11,6 +11,7 @@
     },
     "dataset_options": {
         "include_metadata_export": true,
+        "include_access_request": false,
         "default_tab": "subdatasets"
     },
     "property_sources": {

--- a/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/ddb/8aa081e7afeb3831fe007a3816dce.json
+++ b/datalad_catalog/catalog/metadata/deabeb9b-7a37-4062-a1e0-8fcef7909609/6d7fb68264f9b9951ae141fc830712a8744e3293/ddb/8aa081e7afeb3831fe007a3816dce.json
@@ -32,6 +32,9 @@
     "url": [
         "https://github.com/psychoinformatics-de/studyforrest-data"
     ],
+    "homepage_url": [
+        "https://www.studyforrest.org/"
+    ],
     "authors": [
         {
             "name": "Adina Wagner",

--- a/datalad_catalog/catalog/schema/jsonschema_dataset.json
+++ b/datalad_catalog/catalog/schema/jsonschema_dataset.json
@@ -48,7 +48,23 @@
     },
     "url": {
       "description": "The location of the datalad dataset's annex",
-      "title": "URL",
+      "title": "DataLad URL",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "download_url": {
+      "description": "The URL at which the complete dataset can be downloaded directly, typically via HTTP protocol and without further access restrictions",
+      "title": "Download URL",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "homepage_url": {
+      "description": "A unique URL with content that describes the current dataset and which may provide further data access",
+      "title": "Homepage URL",
       "type": ["array", "string"],
       "items": {
         "type": "string"

--- a/datalad_catalog/catalog/templates/dataset-template.html
+++ b/datalad_catalog/catalog/templates/dataset-template.html
@@ -46,6 +46,8 @@
               alt="binder_logo" height="14em" class="mb-1">Explore with Binder</b-button>&nbsp;</span>
             <span><b-button variant="outline-dark" size="sm" v-b-modal.modal-4><i class="fas fa-share"></i> Share</b-button>&nbsp;</span>
             <span style="margin-left: auto;">
+              <span v-if="displayData.show_homepage"><b-button variant="outline-dark" size="sm" :href="displayData.homepage_url" target="_blank"><i class="fas fa-house"></i> Homepage</b-button>&nbsp;</span>
+              <span v-if="displayData.show_download"><b-button variant="outline-dark" size="sm" :href="displayData.download_url" target="_blank"><i class="fas fa-download"></i> Download</b-button>&nbsp;</span>
               <span v-if="displayData.show_access_request && selectedDataset.access_request_contact"><b-button variant="outline-dark" size="sm" :href="displayData.access_request_mailto"><i class="far fa-envelope"></i> Request access</b-button>&nbsp;</span>
               <span v-if="displayData.show_access_request && selectedDataset.access_request_url"><b-button variant="outline-dark" size="sm" @click="gotoURL(selectedDataset.access_request_url)"><i class="fas fa-share"></i> Request access</b-button></span>
             </span>

--- a/datalad_catalog/config/config.json
+++ b/datalad_catalog/config/config.json
@@ -19,7 +19,9 @@
         "include_binder": true,
         "include_cite": true,
         "include_metadata_export": true,
-        "include_access_request": true
+        "include_access_request": true,
+        "include_homepage": true,
+        "include_download": true
     },
     "property_sources": {
         "dataset": {

--- a/datalad_catalog/tests/test_schema_utils.py
+++ b/datalad_catalog/tests/test_schema_utils.py
@@ -14,6 +14,8 @@ ds = {
     "description": "",
     "doi": "",
     "url": "",
+    "download_url": "",
+    "homepage_url": "",
     "license": {"name": "", "url": ""},
     "authors": [
         {


### PR DESCRIPTION
These two fields are new properties in the dataset schema, and allow dissociation from the existing `url` field, which is specific to a datalad dataset. The visibility of these buttons can also be controlled via associated show/hide fields in the catalog or dataset-level config. The demo dataset config and metadata has been updated to demonstrate the homepage button, and the default config has been updated to include the new controlling flags.