### PR TITLE
Change `--type` flag to `--mode` for workflow usage docs

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -243,7 +243,7 @@ To run a workflow from scratch on a dataset and all of its subdatasets:
 
 .. code-block:: bash
 
-   datalad catalog-workflow --type new --catalog /tmp/my-cat --dataset path/to/superdataset --extractor metalad_core
+   datalad catalog-workflow --mode new --catalog /tmp/my-cat --dataset path/to/superdataset --extractor metalad_core
 
 This workflow will:
 
@@ -261,7 +261,7 @@ to the superdataset which the catalog represents:
 
 .. code-block:: bash
 
-   datalad catalog-workflow --type update --catalog /tmp/my-cat --dataset path/to/superdataset --subdataset path/to/subdataset --extractor metalad_core
+   datalad catalog-workflow --mode update --catalog /tmp/my-cat --dataset path/to/superdataset --subdataset path/to/subdataset --extractor metalad_core
 
 This workflow assumes:
 


### PR DESCRIPTION
For the `catalog-workflow` command, the `--type` flag was changed to `--mode` a while back because of an error, see https://github.com/datalad/datalad-catalog/commit/be138c524cce7ed545a6ab2a534685c1b04bc962. The docs weren't updated accordingly. Now they are.